### PR TITLE
Fix shift left overflow in test_msm_ux when bit_width is 64

### DIFF
--- a/src/provider/msm.rs
+++ b/src/provider/msm.rs
@@ -482,7 +482,14 @@ mod tests {
       println!("bit_width: {bit_width}");
       assert!(bit_width <= 64); // Ensure we don't overflow F::from
       let coeffs: Vec<u64> = (0..n)
-        .map(|_| rand::random::<u64>() % (1 << bit_width))
+        .map(|_| {
+          let r = rand::random::<u64>();
+          if bit_width == 64 {
+            r
+          } else {
+            r % (1 << bit_width)
+          }
+        })
         .collect::<Vec<_>>();
       let coeffs_scalar: Vec<F> = coeffs.iter().map(|b| F::from(*b)).collect::<Vec<_>>();
       let general = msm(&coeffs_scalar, &bases, true);


### PR DESCRIPTION
`1 << 64` overflows since shifting a u64 by 64 positions exceeds its bit width. Skip the modulo when bit_width == 64 since any u64 value is already in range.