### PR TITLE
Rename crate to vega-prover

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,4 +1,4 @@
-name: Build and Test Spartan2
+name: Build and Test vega-prover
 
 permissions:
   contents: read

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
-name = "spartan2"
+name = "vega-prover"
 version = "0.9.0"
 authors = ["Srinath Setty <srinath@microsoft.com>"]
 edition = "2024"
-description = "High-speed zkSNARKs without trusted setup"
-documentation = "https://docs.rs/spartan2"
+description = "Client-side ZK provers of Vega for low-latency proving over signed data"
+documentation = "https://docs.rs/vega-prover"
 readme = "README.md"
-repository = "https://github.com/Microsoft/Spartan2"
+repository = "https://github.com/Microsoft/vega-prover"
 license-file = "LICENSE"
 keywords = ["zkSNARKs", "cryptography", "proofs"]
 
@@ -62,11 +62,11 @@ default = []
 jem = ["tikv-jemallocator"]
 
 [[bench]]
-name = "sha256_spartan"
+name = "sha256_vega_sc"
 harness = false
 
 [[bench]]
-name = "sha256_neutronnova"
+name = "sha256_vega_mc_zkp"
 harness = false
 
 [profile.release]

--- a/README.md
+++ b/README.md
@@ -1,79 +1,29 @@
-# Spartan and NeutronNova: Fast client-side zero-knowledge proving systems
+# vega-prover: Low-latency client-side ZK proving over signed data
 
-A client-side zkSNARK library built on the Spartan sum-check proof
-system and NeutronNova's folding scheme. Spartan2 powers
-[Vega](https://eprint.iacr.org/2025/2094).
-
-## What this library provides
-
-- **Spartan zkSNARK** — a PCS-generic Rust implementation of
-  [Spartan](https://eprint.iacr.org/2019/550), a sum-check-based zkSNARK
-  with a linear-time prover. Accepts R1CS circuits written with
-  [bellpepper](https://github.com/lurk-lab/bellpepper). Spartan is
-  PCS-agnostic and works with any multilinear polynomial commitment
-  scheme (Hyrax, HyperKZG, Binius, WHIR, BaseFold, Dory, PST13, …); the
-  choice determines field size, security model (pre- or post-quantum),
-  setup assumptions (transparent or universal), and commitment style
-  (hash- or curve-based). While Spartan supports R1CS, Plonkish, AIR,
-  and CCS in principle (with lookup constraints fitting natively via
-  Spartan's internal lookup arguments), this library currently exposes
-  the R1CS frontend. Zero-knowledge is obtained via Nova's folding
-  scheme. The Spark optimization is not implemented, so verifier work
-  is proportional to the number of non-zero R1CS entries.
-
-- **NeutronNova zkSNARK** — a non-recursive implementation of
-  [NeutronNova](https://eprint.iacr.org/2024/1606) folding for uniform
-  computations: given many instances of a single **step circuit**, all
-  R1CS instances are multi-folded into one and the folded instance is
-  proved with Spartan, amortizing the prover across the batch. An
-  optional **core circuit** can tie the batch together (e.g., to
-  enforce cross-step consistency).
-
-- **Precomputable / online witness split.** Both protocols expose
-  `setup` → `prep_prove` → `prove`. `setup` produces circuit-shape key
-  material. `prep_prove` processes the *precomputable* witness — the
-  portion known ahead of proving time — synthesizing and committing to
-  it; for NeutronNova it also caches the per-step matrix-vector
-  products (`Az`, `Bz`, `Cz`). `prove` consumes fresh *online* witness
-  data (challenges, rest-witness, fresh randomness), runs NeutronNova's
-  multi-folding rounds where applicable, and produces the final proof.
-  The `prep_prove` state can be reused across multiple `prove` calls,
-  so amortizable work is paid once. This is the pattern
-  [Vega](https://eprint.iacr.org/2025/2094) relies on for low-latency
-  proving.
-
-- **Criterion benchmarks** — `benches/sha256_spartan.rs` and
-  `benches/sha256_neutronnova.rs` measure setup, prep_prove, prove, and
-  verify across message sizes and thread counts, and report proof
-  sizes.
+This repository implements the ZK provers of [Vega](https://eprint.iacr.org/2025/2094). They are used for client-side ZK proving of statements over signed data. We focus on optimizing low proving latency, and on settings where statements are proven repeatedly over the same signed data.
 
 ## Running benchmarks
 
-The `benches/` directory contains SHA-256 benchmarks for both protocols using [Criterion](https://github.com/bheisler/criterion.rs). Each benchmark measures setup, prep_prove, prove, and verify times across multiple iterations and thread counts, and reports proof sizes.
+> [!IMPORTANT]
+> We optimize for low ZK proving latency on the signed messages typical in practice — not for raw throughput on artificial, high-volume workloads.
+
+The `benches/` directory contains SHA-256 benchmarks using [Criterion](https://github.com/bheisler/criterion.rs). Each benchmark measures setup, prep_prove, prove, and verify times across multiple iterations and thread counts, and reports proof sizes.
 
 ```bash
-# Spartan: SHA-256 over 1 KiB and 2 KiB messages
-RUSTFLAGS="-C target-cpu=native" cargo bench --bench sha256_spartan
+# Single-circuit (SC) prover: SHA-256 over 1 KiB and 2 KiB messages
+RUSTFLAGS="-C target-cpu=native" cargo bench --bench sha256_vega_sc
 
-# NeutronNova: 32 SHA-256 step circuits (2048 bytes total)
-RUSTFLAGS="-C target-cpu=native" cargo bench --bench sha256_neutronnova
+# Multi-circuit (MC) prover: 32 SHA-256 step circuits (2048 bytes total)
+RUSTFLAGS="-C target-cpu=native" cargo bench --bench sha256_vega_mc_zkp
 ```
 
 Override thread counts with `BENCH_THREADS` (comma-separated):
 
 ```bash
-BENCH_THREADS=1,8 RUSTFLAGS="-C target-cpu=native" cargo bench --bench sha256_spartan
+BENCH_THREADS=1,8 RUSTFLAGS="-C target-cpu=native" cargo bench --bench sha256_vega_sc
 ```
 
 ## References
-
-[Spartan: Efficient and general-purpose zkSNARKs without trusted setup](https://eprint.iacr.org/2019/550) \
-Srinath Setty \
-CRYPTO 2020
-
-[NeutronNova: Folding everything that reduces to zero-check](https://eprint.iacr.org/2024/1606) \
-Abhiram Kothapalli, Srinath Setty \
-IACR ePrint 2024/1606
 
 [Vega: Low-latency zero-knowledge proofs over existing credentials](https://eprint.iacr.org/2025/2094) \
 Darya Kaviani, Srinath Setty \

--- a/benches/sha256_vega_mc_zkp.rs
+++ b/benches/sha256_vega_mc_zkp.rs
@@ -1,14 +1,14 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
-// This file is part of the Spartan2 project.
+// This file is part of the vega-prover project.
 // See the LICENSE file in the project root for full license information.
-// Source repository: https://github.com/Microsoft/Spartan2
+// Source repository: https://github.com/Microsoft/vega-prover
 
-//! benches/sha256_neutronnova.rs
-//! Criterion benchmarks for NeutronNova {setup, prep_prove, prove, verify}
+//! benches/sha256_vega_mc_zkp.rs
+//! Criterion benchmarks for Vega MC {setup, prep_prove, prove, verify}
 //! on a batch of SHA-256 single-block compressions.
 //!
-//! Run with: `RUSTFLAGS="-C target-cpu=native" cargo bench --bench sha256_neutronnova`
+//! Run with: `RUSTFLAGS="-C target-cpu=native" cargo bench --bench sha256_vega_mc_zkp`
 //! Override thread counts with `BENCH_THREADS=1,4,8`.
 
 #[cfg(feature = "jem")]
@@ -25,12 +25,12 @@ use bellpepper_core::{
 };
 use criterion::{BatchSize, Criterion, Throughput, criterion_group, criterion_main};
 use ff::Field;
-use spartan2::{
-  neutronnova_zk::NeutronNovaZkSNARK,
-  provider::T256HyraxEngine,
-  traits::{Engine, circuit::SpartanCircuit},
-};
 use std::{marker::PhantomData, time::Duration};
+use vega_prover::{
+  provider::T256HyraxEngine,
+  traits::{Engine, circuit::VegaCircuit},
+  vega_mc_zkp::VegaMcZkSNARK,
+};
 
 type E = T256HyraxEngine;
 
@@ -63,7 +63,7 @@ impl<Eng: Engine> Sha256StepCircuit<Eng> {
   }
 }
 
-impl<Eng: Engine> SpartanCircuit<Eng> for Sha256StepCircuit<Eng> {
+impl<Eng: Engine> VegaCircuit<Eng> for Sha256StepCircuit<Eng> {
   fn public_values(&self) -> Result<Vec<Eng::Scalar>, SynthesisError> {
     Ok(vec![Eng::Scalar::ZERO])
   }
@@ -128,7 +128,7 @@ impl<Eng: Engine> SpartanCircuit<Eng> for Sha256StepCircuit<Eng> {
 }
 
 /// Trivial core circuit: just exposes a single public input. Preserves the
-/// "N step circuits + 1 core circuit" structure that NeutronNova requires.
+/// "N step circuits + 1 core circuit" structure that Vega MC requires.
 #[derive(Clone, Debug)]
 struct CoreCircuit<Eng: Engine>(PhantomData<Eng>);
 
@@ -138,7 +138,7 @@ impl<Eng: Engine> CoreCircuit<Eng> {
   }
 }
 
-impl<Eng: Engine> SpartanCircuit<Eng> for CoreCircuit<Eng> {
+impl<Eng: Engine> VegaCircuit<Eng> for CoreCircuit<Eng> {
   fn public_values(&self) -> Result<Vec<Eng::Scalar>, SynthesisError> {
     Ok(vec![Eng::Scalar::ZERO])
   }
@@ -222,7 +222,7 @@ fn make_step_circuits(num_steps: usize) -> Vec<Sha256StepCircuit<E>> {
     .collect()
 }
 
-fn neutronnova_benches(c: &mut Criterion) {
+fn vega_mc_zkp_benches(c: &mut Criterion) {
   let thread_counts = thread_counts();
 
   // Report proof sizes once per size (outside measurements).
@@ -230,16 +230,15 @@ fn neutronnova_benches(c: &mut Criterion) {
     let num_steps = num_steps_for_size(size);
     let step_proto = Sha256StepCircuit::<E>::new([0u8; BLOCK_BYTES]);
     let core_proto = CoreCircuit::<E>::new();
-    let (pk, _vk) = NeutronNovaZkSNARK::<E>::setup(&step_proto, &core_proto, num_steps).unwrap();
+    let (pk, _vk) = VegaMcZkSNARK::<E>::setup(&step_proto, &core_proto, num_steps).unwrap();
     let step_circuits = make_step_circuits(num_steps);
     let core_circuit = CoreCircuit::<E>::new();
-    let prep =
-      NeutronNovaZkSNARK::<E>::prep_prove(&pk, &step_circuits, &core_circuit, true).unwrap();
+    let prep = VegaMcZkSNARK::<E>::prep_prove(&pk, &step_circuits, &core_circuit, true).unwrap();
     let (proof, _) =
-      NeutronNovaZkSNARK::<E>::prove(&pk, &step_circuits, &core_circuit, prep, true).unwrap();
+      VegaMcZkSNARK::<E>::prove(&pk, &step_circuits, &core_circuit, prep, true).unwrap();
     let proof_bytes = bincode::serialize(&proof).unwrap();
     println!(
-      "NeutronNova SHA-256 size={}B num_steps={} (= {} compressions): proof_size={} bytes",
+      "Vega MC SHA-256 size={}B num_steps={} (= {} compressions): proof_size={} bytes",
       size,
       num_steps,
       num_steps,
@@ -247,7 +246,7 @@ fn neutronnova_benches(c: &mut Criterion) {
     );
   }
 
-  let mut g = c.benchmark_group("neutronnova_sha256");
+  let mut g = c.benchmark_group("vega_mc_zkp_sha256");
   g.sample_size(10);
   g.warm_up_time(Duration::from_millis(100));
   g.measurement_time(Duration::from_secs(10));
@@ -267,7 +266,7 @@ fn neutronnova_benches(c: &mut Criterion) {
           pool.install(|| {
             let step_proto = Sha256StepCircuit::<E>::new([0u8; BLOCK_BYTES]);
             let core_proto = CoreCircuit::<E>::new();
-            let _ = NeutronNovaZkSNARK::<E>::setup(&step_proto, &core_proto, num_steps).unwrap();
+            let _ = VegaMcZkSNARK::<E>::setup(&step_proto, &core_proto, num_steps).unwrap();
           });
         });
       });
@@ -278,7 +277,7 @@ fn neutronnova_benches(c: &mut Criterion) {
             pool.install(|| {
               let step_proto = Sha256StepCircuit::<E>::new([0u8; BLOCK_BYTES]);
               let core_proto = CoreCircuit::<E>::new();
-              NeutronNovaZkSNARK::<E>::setup(&step_proto, &core_proto, num_steps)
+              VegaMcZkSNARK::<E>::setup(&step_proto, &core_proto, num_steps)
                 .unwrap()
                 .0
             })
@@ -287,8 +286,8 @@ fn neutronnova_benches(c: &mut Criterion) {
             pool.install(|| {
               let step_circuits = make_step_circuits(num_steps);
               let core_circuit = CoreCircuit::<E>::new();
-              let _ = NeutronNovaZkSNARK::<E>::prep_prove(&pk, &step_circuits, &core_circuit, true)
-                .unwrap();
+              let _ =
+                VegaMcZkSNARK::<E>::prep_prove(&pk, &step_circuits, &core_circuit, true).unwrap();
             });
           },
           BatchSize::LargeInput,
@@ -302,24 +301,21 @@ fn neutronnova_benches(c: &mut Criterion) {
               let step_proto = Sha256StepCircuit::<E>::new([0u8; BLOCK_BYTES]);
               let core_proto = CoreCircuit::<E>::new();
               let (pk, _vk) =
-                NeutronNovaZkSNARK::<E>::setup(&step_proto, &core_proto, num_steps).unwrap();
+                VegaMcZkSNARK::<E>::setup(&step_proto, &core_proto, num_steps).unwrap();
               let step_circuits = make_step_circuits(num_steps);
               let core_circuit = CoreCircuit::<E>::new();
               let prep =
-                NeutronNovaZkSNARK::<E>::prep_prove(&pk, &step_circuits, &core_circuit, true)
-                  .unwrap();
+                VegaMcZkSNARK::<E>::prep_prove(&pk, &step_circuits, &core_circuit, true).unwrap();
               // Warm-up prove
               let (_proof, prep_back) =
-                NeutronNovaZkSNARK::<E>::prove(&pk, &step_circuits, &core_circuit, prep, true)
-                  .unwrap();
+                VegaMcZkSNARK::<E>::prove(&pk, &step_circuits, &core_circuit, prep, true).unwrap();
               (pk, step_circuits, core_circuit, prep_back)
             })
           },
           |(pk, step_circuits, core_circuit, prep)| {
             pool.install(|| {
               let _ =
-                NeutronNovaZkSNARK::<E>::prove(&pk, &step_circuits, &core_circuit, prep, true)
-                  .unwrap();
+                VegaMcZkSNARK::<E>::prove(&pk, &step_circuits, &core_circuit, prep, true).unwrap();
             });
           },
           BatchSize::LargeInput,
@@ -333,15 +329,13 @@ fn neutronnova_benches(c: &mut Criterion) {
               let step_proto = Sha256StepCircuit::<E>::new([0u8; BLOCK_BYTES]);
               let core_proto = CoreCircuit::<E>::new();
               let (pk, vk) =
-                NeutronNovaZkSNARK::<E>::setup(&step_proto, &core_proto, num_steps).unwrap();
+                VegaMcZkSNARK::<E>::setup(&step_proto, &core_proto, num_steps).unwrap();
               let step_circuits = make_step_circuits(num_steps);
               let core_circuit = CoreCircuit::<E>::new();
               let prep =
-                NeutronNovaZkSNARK::<E>::prep_prove(&pk, &step_circuits, &core_circuit, true)
-                  .unwrap();
+                VegaMcZkSNARK::<E>::prep_prove(&pk, &step_circuits, &core_circuit, true).unwrap();
               let (proof, _) =
-                NeutronNovaZkSNARK::<E>::prove(&pk, &step_circuits, &core_circuit, prep, true)
-                  .unwrap();
+                VegaMcZkSNARK::<E>::prove(&pk, &step_circuits, &core_circuit, prep, true).unwrap();
               (vk, proof)
             })
           },
@@ -358,5 +352,5 @@ fn neutronnova_benches(c: &mut Criterion) {
   g.finish();
 }
 
-criterion_group!(benches, neutronnova_benches);
+criterion_group!(benches, vega_mc_zkp_benches);
 criterion_main!(benches);

--- a/benches/sha256_vega_sc.rs
+++ b/benches/sha256_vega_sc.rs
@@ -1,14 +1,14 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
-// This file is part of the Spartan2 project.
+// This file is part of the vega-prover project.
 // See the LICENSE file in the project root for full license information.
-// Source repository: https://github.com/Microsoft/Spartan2
+// Source repository: https://github.com/Microsoft/vega-prover
 
-//! benches/sha256_spartan.rs
-//! Criterion benchmarks for Spartan {setup, prep_prove, prove, verify}
+//! benches/sha256_vega_sc.rs
+//! Criterion benchmarks for Vega SC {setup, prep_prove, prove, verify}
 //! on a SHA-256 circuit with varying message lengths.
 //!
-//! Run with: `RUSTFLAGS="-C target-cpu=native" cargo bench --bench sha256_spartan`
+//! Run with: `RUSTFLAGS="-C target-cpu=native" cargo bench --bench sha256_vega_sc`
 #[cfg(feature = "jem")]
 use tikv_jemallocator::Jemalloc;
 #[cfg(feature = "jem")]
@@ -24,12 +24,12 @@ use bellpepper_core::{
 use criterion::{BatchSize, Criterion, Throughput, criterion_group, criterion_main};
 use ff::{Field, PrimeField, PrimeFieldBits};
 use sha2::{Digest, Sha256};
-use spartan2::{
-  provider::T256HyraxEngine,
-  spartan::SpartanSNARK,
-  traits::{Engine, circuit::SpartanCircuit, snark::R1CSSNARKTrait},
-};
 use std::{marker::PhantomData, time::Duration};
+use vega_prover::{
+  provider::T256HyraxEngine,
+  traits::{Engine, circuit::VegaCircuit, snark::R1CSSNARKTrait},
+  vega_sc::VegaSNARK,
+};
 
 type E = T256HyraxEngine;
 
@@ -48,7 +48,7 @@ impl<Scalar: PrimeField + PrimeFieldBits> Sha256Circuit<Scalar> {
   }
 }
 
-impl<E: Engine> SpartanCircuit<E> for Sha256Circuit<E::Scalar> {
+impl<E: Engine> VegaCircuit<E> for Sha256Circuit<E::Scalar> {
   fn public_values(&self) -> Result<Vec<<E as Engine>::Scalar>, SynthesisError> {
     let mut hasher = Sha256::new();
     hasher.update(&self.preimage);
@@ -163,25 +163,25 @@ fn thread_counts() -> Vec<usize> {
   }
 }
 
-fn spartan_benches(c: &mut Criterion) {
+fn vega_sc_benches(c: &mut Criterion) {
   let sizes = [1024usize, 2048];
   let thread_counts = thread_counts();
 
   // Report proof sizes once (outside measurements)
   for &size in &sizes {
     let circuit = Sha256Circuit::<<E as Engine>::Scalar>::new(vec![0u8; size]);
-    let (pk, _vk) = SpartanSNARK::<E>::setup(circuit.clone()).unwrap();
-    let prep = SpartanSNARK::<E>::prep_prove(&pk, circuit.clone(), true).unwrap();
-    let (proof, _) = SpartanSNARK::<E>::prove(&pk, circuit, prep, true).unwrap();
+    let (pk, _vk) = VegaSNARK::<E>::setup(circuit.clone()).unwrap();
+    let prep = VegaSNARK::<E>::prep_prove(&pk, circuit.clone(), true).unwrap();
+    let (proof, _) = VegaSNARK::<E>::prove(&pk, circuit, prep, true).unwrap();
     let proof_bytes = bincode::serialize(&proof).unwrap();
     println!(
-      "Spartan SHA-256 msg={}B: proof_size={} bytes",
+      "Vega SC SHA-256 msg={}B: proof_size={} bytes",
       size,
       proof_bytes.len()
     );
   }
 
-  let mut g = c.benchmark_group("spartan_sha256");
+  let mut g = c.benchmark_group("vega_sc_sha256");
   g.sample_size(10);
   g.warm_up_time(Duration::from_millis(100));
   g.measurement_time(Duration::from_secs(10));
@@ -198,7 +198,7 @@ fn spartan_benches(c: &mut Criterion) {
         b.iter(|| {
           pool.install(|| {
             let circuit = Sha256Circuit::<<E as Engine>::Scalar>::new(vec![0u8; size]);
-            let _ = SpartanSNARK::<E>::setup(circuit).unwrap();
+            let _ = VegaSNARK::<E>::setup(circuit).unwrap();
           });
         });
       });
@@ -208,13 +208,13 @@ fn spartan_benches(c: &mut Criterion) {
           || {
             pool.install(|| {
               let circuit = Sha256Circuit::<<E as Engine>::Scalar>::new(vec![0u8; size]);
-              SpartanSNARK::<E>::setup(circuit).unwrap().0
+              VegaSNARK::<E>::setup(circuit).unwrap().0
             })
           },
           |pk| {
             pool.install(|| {
               let circuit = Sha256Circuit::<<E as Engine>::Scalar>::new(vec![0u8; size]);
-              let _ = SpartanSNARK::<E>::prep_prove(&pk, circuit, true).unwrap();
+              let _ = VegaSNARK::<E>::prep_prove(&pk, circuit, true).unwrap();
             });
           },
           BatchSize::LargeInput,
@@ -226,17 +226,17 @@ fn spartan_benches(c: &mut Criterion) {
           || {
             pool.install(|| {
               let circuit = Sha256Circuit::<<E as Engine>::Scalar>::new(vec![0u8; size]);
-              let (pk, _vk) = SpartanSNARK::<E>::setup(circuit.clone()).unwrap();
-              let prep = SpartanSNARK::<E>::prep_prove(&pk, circuit.clone(), true).unwrap();
+              let (pk, _vk) = VegaSNARK::<E>::setup(circuit.clone()).unwrap();
+              let prep = VegaSNARK::<E>::prep_prove(&pk, circuit.clone(), true).unwrap();
               // Warm-up prove
               let (_proof, prep_back) =
-                SpartanSNARK::<E>::prove(&pk, circuit.clone(), prep, true).unwrap();
+                VegaSNARK::<E>::prove(&pk, circuit.clone(), prep, true).unwrap();
               (pk, circuit, prep_back)
             })
           },
           |(pk, circuit, prep)| {
             pool.install(|| {
-              let _ = SpartanSNARK::<E>::prove(&pk, circuit, prep, true).unwrap();
+              let _ = VegaSNARK::<E>::prove(&pk, circuit, prep, true).unwrap();
             });
           },
           BatchSize::LargeInput,
@@ -248,9 +248,9 @@ fn spartan_benches(c: &mut Criterion) {
           || {
             pool.install(|| {
               let circuit = Sha256Circuit::<<E as Engine>::Scalar>::new(vec![0u8; size]);
-              let (pk, vk) = SpartanSNARK::<E>::setup(circuit.clone()).unwrap();
-              let prep = SpartanSNARK::<E>::prep_prove(&pk, circuit.clone(), true).unwrap();
-              let (proof, _) = SpartanSNARK::<E>::prove(&pk, circuit, prep, true).unwrap();
+              let (pk, vk) = VegaSNARK::<E>::setup(circuit.clone()).unwrap();
+              let prep = VegaSNARK::<E>::prep_prove(&pk, circuit.clone(), true).unwrap();
+              let (proof, _) = VegaSNARK::<E>::prove(&pk, circuit, prep, true).unwrap();
               (vk, proof)
             })
           },
@@ -267,5 +267,5 @@ fn spartan_benches(c: &mut Criterion) {
   g.finish();
 }
 
-criterion_group!(benches, spartan_benches);
+criterion_group!(benches, vega_sc_benches);
 criterion_main!(benches);

--- a/src/bellpepper/mod.rs
+++ b/src/bellpepper/mod.rs
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
-// This file is part of the Spartan2 project.
+// This file is part of the vega-prover project.
 // See the LICENSE file in the project root for full license information.
-// Source repository: https://github.com/Microsoft/Spartan2
+// Source repository: https://github.com/Microsoft/vega-prover
 
 //! Support for generating R1CS from Bellpepper
 pub mod r1cs;
@@ -16,7 +16,7 @@ mod tests {
   use crate::{
     bellpepper::{
       solver::SatisfyingAssignment,
-      test_r1cs::{TestSpartanShape, TestSpartanWitness},
+      test_r1cs::{TestVegaShape, TestVegaWitness},
       test_shape_cs::TestShapeCS,
     },
     provider::PallasHyraxEngine,
@@ -73,7 +73,7 @@ mod tests {
   // ------------------------------------------------------------
   use crate::{
     bellpepper::{
-      r1cs::{MultiRoundSpartanShape, MultiRoundSpartanWitness},
+      r1cs::{MultiRoundVegaShape, MultiRoundVegaWitness},
       shape_cs::ShapeCS,
     },
     traits::{circuit::MultiRoundCircuit, transcript::TranscriptEngineTrait},
@@ -122,7 +122,7 @@ mod tests {
 
     // Generate shape
     let (shape, ck, _vk) =
-      <ShapeCS<E> as MultiRoundSpartanShape<E>>::multiround_r1cs_shape(&circuit).unwrap();
+      <ShapeCS<E> as MultiRoundVegaShape<E>>::multiround_r1cs_shape(&circuit).unwrap();
 
     // Initialize witness state
     let mut state = SatisfyingAssignment::<E>::initialize_multiround_witness(&shape).unwrap();
@@ -342,7 +342,7 @@ mod tests {
 
     // Generate shape
     let (shape, ck, _vk) =
-      <ShapeCS<E> as MultiRoundSpartanShape<E>>::multiround_r1cs_shape(&circuit).unwrap();
+      <ShapeCS<E> as MultiRoundVegaShape<E>>::multiround_r1cs_shape(&circuit).unwrap();
 
     // Initialize witness state
     let mut state = SatisfyingAssignment::<E>::initialize_multiround_witness(&shape).unwrap();

--- a/src/bellpepper/r1cs.rs
+++ b/src/bellpepper/r1cs.rs
@@ -1,22 +1,22 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
-// This file is part of the Spartan2 project.
+// This file is part of the vega-prover project.
 // See the LICENSE file in the project root for full license information.
-// Source repository: https://github.com/Microsoft/Spartan2
+// Source repository: https://github.com/Microsoft/vega-prover
 
 //! Support for generating R1CS using bellpepper.
 use crate::start_span;
 use crate::{
   Blind, Commitment, CommitmentKey, PCS, VerifierKey,
   bellpepper::{shape_cs::ShapeCS, solver::SatisfyingAssignment},
-  errors::SpartanError,
+  errors::VegaError,
   r1cs::{
     R1CSWitness, SparseMatrix, SplitMultiRoundR1CSInstance, SplitMultiRoundR1CSShape,
     SplitR1CSInstance, SplitR1CSShape,
   },
   traits::{
     Engine,
-    circuit::{MultiRoundCircuit, SpartanCircuit},
+    circuit::{MultiRoundCircuit, VegaCircuit},
     pcs::PCSEngineTrait,
     transcript::TranscriptEngineTrait,
   },
@@ -27,16 +27,16 @@ use ff::{Field, PrimeField};
 use serde::{Deserialize, Serialize};
 use tracing::{debug, info};
 
-/// `SpartanShape` provides methods for acquiring `SplitR1CSShape` from implementers.
-pub trait SpartanShape<E: Engine> {
+/// `VegaShape` provides methods for acquiring `SplitR1CSShape` from implementers.
+pub trait VegaShape<E: Engine> {
   /// Return an appropriate `SplitR1CSShape`
-  fn r1cs_shape<C: SpartanCircuit<E>>(circuit: &C) -> Result<SplitR1CSShape<E>, SpartanError>;
+  fn r1cs_shape<C: VegaCircuit<E>>(circuit: &C) -> Result<SplitR1CSShape<E>, VegaError>;
 }
 
 /// Defines rerandomization behavior for preprocessed state
 pub trait RerandomizationTrait<E: Engine> {
   /// Returns a rerandomized version of self.
-  fn rerandomize(&self, ck: &CommitmentKey<E>, S: &SplitR1CSShape<E>) -> Result<Self, SpartanError>
+  fn rerandomize(&self, ck: &CommitmentKey<E>, S: &SplitR1CSShape<E>) -> Result<Self, VegaError>
   where
     Self: Sized;
 
@@ -47,13 +47,13 @@ pub trait RerandomizationTrait<E: Engine> {
     S: &SplitR1CSShape<E>,
     comm_W_shared: &Option<Commitment<E>>,
     r_W_shared: &Option<Blind<E>>,
-  ) -> Result<Self, SpartanError>
+  ) -> Result<Self, VegaError>
   where
     Self: Sized;
 }
 
-/// `SpartanWitness` provide a method for acquiring an `SplitR1CSInstance` and `R1CSWitness` from implementers.
-pub trait SpartanWitness<E: Engine> {
+/// `VegaWitness` provide a method for acquiring an `SplitR1CSInstance` and `R1CSWitness` from implementers.
+pub trait VegaWitness<E: Engine> {
   /// Holds the state of the prover after committing to the precommitted portions of the witness.
   type PrecommittedState: Send
     + Sync
@@ -62,35 +62,35 @@ pub trait SpartanWitness<E: Engine> {
     + RerandomizationTrait<E>;
 
   /// Return partial commitments (to shared variables) and the shared state
-  fn shared_witness<C: SpartanCircuit<E>>(
+  fn shared_witness<C: VegaCircuit<E>>(
     S: &SplitR1CSShape<E>,
     ck: &CommitmentKey<E>,
     circuit: &C,
     is_small: bool,
-  ) -> Result<Self::PrecommittedState, SpartanError>;
+  ) -> Result<Self::PrecommittedState, VegaError>;
 
   /// Return partial commitments (to shared and precommitted variables) and the partial witness vector.
-  fn precommitted_witness<C: SpartanCircuit<E>>(
+  fn precommitted_witness<C: VegaCircuit<E>>(
     ps: &mut Self::PrecommittedState,
     S: &SplitR1CSShape<E>,
     ck: &CommitmentKey<E>,
     circuit: &C,
     is_small: bool,
-  ) -> Result<(), SpartanError>;
+  ) -> Result<(), VegaError>;
 
   /// Return an instance and witness, given a shape and ck.
-  fn r1cs_instance_and_witness<C: SpartanCircuit<E>>(
+  fn r1cs_instance_and_witness<C: VegaCircuit<E>>(
     ps: &mut Self::PrecommittedState,
     S: &SplitR1CSShape<E>,
     ck: &CommitmentKey<E>,
     circuit: &C,
     is_small: bool,
     transcript: &mut E::TE,
-  ) -> Result<(SplitR1CSInstance<E>, R1CSWitness<E>), SpartanError>;
+  ) -> Result<(SplitR1CSInstance<E>, R1CSWitness<E>), VegaError>;
 }
 
-/// `MultiRoundSpartanShape` provides methods for acquiring `SplitMultiRoundR1CSShape` and `CommitmentKey` from implementers.
-pub trait MultiRoundSpartanShape<E: Engine> {
+/// `MultiRoundVegaShape` provides methods for acquiring `SplitMultiRoundR1CSShape` and `CommitmentKey` from implementers.
+pub trait MultiRoundVegaShape<E: Engine> {
   /// Return an appropriate `SplitMultiRoundR1CSShape` and `CommitmentKey` structs.
   fn multiround_r1cs_shape<C: MultiRoundCircuit<E>>(
     circuit: &C,
@@ -100,19 +100,19 @@ pub trait MultiRoundSpartanShape<E: Engine> {
       CommitmentKey<E>,
       VerifierKey<E>,
     ),
-    SpartanError,
+    VegaError,
   >;
 }
 
-/// `MultiRoundSpartanWitness` provide a method for acquiring an `SplitMultiRoundR1CSInstance` and `R1CSWitness` from implementers.
-pub trait MultiRoundSpartanWitness<E: Engine> {
+/// `MultiRoundVegaWitness` provide a method for acquiring an `SplitMultiRoundR1CSInstance` and `R1CSWitness` from implementers.
+pub trait MultiRoundVegaWitness<E: Engine> {
   /// Holds the state of the prover across multiple rounds.
   type MultiRoundState: Send + Sync + Serialize + for<'de> Deserialize<'de>;
 
   /// Initialize the multi-round witness process and return the initial state.
   fn initialize_multiround_witness(
     s: &SplitMultiRoundR1CSShape<E>,
-  ) -> Result<Self::MultiRoundState, SpartanError>;
+  ) -> Result<Self::MultiRoundState, VegaError>;
 
   /// Process a specific round and update the state, returning the challenges generated after the commitment to the round.
   fn process_round<C: MultiRoundCircuit<E>>(
@@ -122,17 +122,17 @@ pub trait MultiRoundSpartanWitness<E: Engine> {
     circuit: &C,
     round_index: usize,
     transcript: &mut E::TE,
-  ) -> Result<Vec<E::Scalar>, SpartanError>;
+  ) -> Result<Vec<E::Scalar>, VegaError>;
 
   /// Finalize the multi-round witness and return the instance and witness.
   fn finalize_multiround_witness(
     state: &mut Self::MultiRoundState,
     s: &SplitMultiRoundR1CSShape<E>,
-  ) -> Result<(SplitMultiRoundR1CSInstance<E>, R1CSWitness<E>), SpartanError>;
+  ) -> Result<(SplitMultiRoundR1CSInstance<E>, R1CSWitness<E>), VegaError>;
 }
 
-impl<E: Engine> SpartanShape<E> for ShapeCS<E> {
-  fn r1cs_shape<C: SpartanCircuit<E>>(circuit: &C) -> Result<SplitR1CSShape<E>, SpartanError> {
+impl<E: Engine> VegaShape<E> for ShapeCS<E> {
+  fn r1cs_shape<C: VegaCircuit<E>>(circuit: &C) -> Result<SplitR1CSShape<E>, VegaError> {
     let num_challenges = circuit.num_challenges();
 
     let mut cs: Self = Self::new();
@@ -140,7 +140,7 @@ impl<E: Engine> SpartanShape<E> for ShapeCS<E> {
     // allocate shared variables
     let shared = circuit
       .shared(&mut cs)
-      .map_err(|e| SpartanError::SynthesisError {
+      .map_err(|e| VegaError::SynthesisError {
         reason: format!("Unable to allocate shared variables: {e}"),
       })?;
 
@@ -149,7 +149,7 @@ impl<E: Engine> SpartanShape<E> for ShapeCS<E> {
     debug!("num_shared: {}", num_shared);
     debug!("shared.len(): {}", shared.len());
     if shared.len() > num_shared {
-      return Err(SpartanError::SynthesisError {
+      return Err(VegaError::SynthesisError {
         reason: "Shared variables are not allocated correctly".to_string(),
       });
     }
@@ -158,7 +158,7 @@ impl<E: Engine> SpartanShape<E> for ShapeCS<E> {
     let precommitted =
       circuit
         .precommitted(&mut cs, &shared)
-        .map_err(|e| SpartanError::SynthesisError {
+        .map_err(|e| VegaError::SynthesisError {
           reason: format!("Unable to allocate precommitted variables: {e}"),
         })?;
 
@@ -166,7 +166,7 @@ impl<E: Engine> SpartanShape<E> for ShapeCS<E> {
     debug!("num_precommitted: {}", num_precommitted);
     debug!("precommitted.len(): {}", precommitted.len());
     if precommitted.len() > num_precommitted {
-      return Err(SpartanError::SynthesisError {
+      return Err(VegaError::SynthesisError {
         reason: "Precommitted variables are not allocated correctly".to_string(),
       });
     }
@@ -174,7 +174,7 @@ impl<E: Engine> SpartanShape<E> for ShapeCS<E> {
     // synthesize the circuit
     circuit
       .synthesize(&mut cs, &shared, &precommitted, None)
-      .map_err(|e| SpartanError::SynthesisError {
+      .map_err(|e| VegaError::SynthesisError {
         reason: format!("Unable to synthesize circuit: {e}"),
       })?;
 
@@ -300,15 +300,15 @@ pub struct PrecommittedState<E: Engine> {
   pub(crate) W: Vec<E::Scalar>,
 }
 
-impl<E: Engine> SpartanWitness<E> for SatisfyingAssignment<E> {
+impl<E: Engine> VegaWitness<E> for SatisfyingAssignment<E> {
   type PrecommittedState = PrecommittedState<E>;
 
-  fn shared_witness<C: SpartanCircuit<E>>(
+  fn shared_witness<C: VegaCircuit<E>>(
     S: &SplitR1CSShape<E>,
     ck: &CommitmentKey<E>,
     circuit: &C,
     is_small: bool,
-  ) -> Result<Self::PrecommittedState, SpartanError> {
+  ) -> Result<Self::PrecommittedState, VegaError> {
     let (_synth_span, synth_t) = start_span!("shared_witness_synthesize");
     let mut cs: Self = Self::new();
 
@@ -320,13 +320,13 @@ impl<E: Engine> SpartanWitness<E> for SatisfyingAssignment<E> {
     // produce shared witness variables and commit to them
     let shared = circuit
       .shared(&mut cs)
-      .map_err(|e| SpartanError::SynthesisError {
+      .map_err(|e| VegaError::SynthesisError {
         reason: format!("Unable to allocate shared variables: {e}"),
       })?;
 
     // we know that W is large enough to hold all shared variables
     if cs.aux_assignment.len() < S.num_shared_unpadded {
-      return Err(SpartanError::SynthesisError {
+      return Err(VegaError::SynthesisError {
         reason: "Shared variables are not allocated correctly".to_string(),
       });
     }
@@ -356,24 +356,24 @@ impl<E: Engine> SpartanWitness<E> for SatisfyingAssignment<E> {
     })
   }
 
-  fn precommitted_witness<C: SpartanCircuit<E>>(
+  fn precommitted_witness<C: VegaCircuit<E>>(
     ps: &mut Self::PrecommittedState,
     S: &SplitR1CSShape<E>,
     ck: &CommitmentKey<E>,
     circuit: &C,
     is_small: bool,
-  ) -> Result<(), SpartanError> {
+  ) -> Result<(), VegaError> {
     let (_synth_span, synth_t) = start_span!("precommitted_witness_synthesize");
     // produce precommitted witness variables
     let precommitted =
       circuit
         .precommitted(&mut ps.cs, &ps.shared)
-        .map_err(|e| SpartanError::SynthesisError {
+        .map_err(|e| VegaError::SynthesisError {
           reason: format!("Unable to allocate precommitted variables: {e}"),
         })?;
 
     if ps.cs.aux_assignment[S.num_shared_unpadded..].len() < S.num_precommitted_unpadded {
-      return Err(SpartanError::SynthesisError {
+      return Err(VegaError::SynthesisError {
         reason: "Precommitted variables are not allocated correctly".to_string(),
       });
     }
@@ -408,14 +408,14 @@ impl<E: Engine> SpartanWitness<E> for SatisfyingAssignment<E> {
     Ok(())
   }
 
-  fn r1cs_instance_and_witness<C: SpartanCircuit<E>>(
+  fn r1cs_instance_and_witness<C: VegaCircuit<E>>(
     ps: &mut Self::PrecommittedState,
     S: &SplitR1CSShape<E>,
     ck: &CommitmentKey<E>,
     circuit: &C,
     is_small: bool,
     transcript: &mut E::TE,
-  ) -> Result<(SplitR1CSInstance<E>, R1CSWitness<E>), SpartanError> {
+  ) -> Result<(SplitR1CSInstance<E>, R1CSWitness<E>), VegaError> {
     let (_synth_span, synth_t) = start_span!("circuit_synthesize_rest");
 
     // partial commitment to precommitted witness variables
@@ -428,7 +428,7 @@ impl<E: Engine> SpartanWitness<E> for SatisfyingAssignment<E> {
 
     let challenges = (0..S.num_challenges)
       .map(|_| transcript.squeeze(b"challenge"))
-      .collect::<Result<Vec<E::Scalar>, SpartanError>>()?;
+      .collect::<Result<Vec<E::Scalar>, VegaError>>()?;
 
     // Fast path: skip circuit synthesis when there are no rest witness variables to compute
     // and no verifier challenges to process. In this case, the witness W is already fully
@@ -450,7 +450,7 @@ impl<E: Engine> SpartanWitness<E> for SatisfyingAssignment<E> {
 
       circuit
         .synthesize(&mut ps.cs, &ps.shared, &ps.precommitted, Some(&challenges))
-        .map_err(|e| SpartanError::SynthesisError {
+        .map_err(|e| VegaError::SynthesisError {
           reason: format!("Unable to synthesize witness: {e}"),
         })?;
 
@@ -493,7 +493,7 @@ impl<E: Engine> SpartanWitness<E> for SatisfyingAssignment<E> {
     let public_values = if skip_synthesize {
       circuit
         .public_values()
-        .map_err(|e| SpartanError::SynthesisError {
+        .map_err(|e| VegaError::SynthesisError {
           reason: format!("Circuit does not provide public IO: {e}"),
         })?
     } else {
@@ -538,7 +538,7 @@ impl<E: Engine> SpartanWitness<E> for SatisfyingAssignment<E> {
 }
 
 impl<E: Engine> RerandomizationTrait<E> for PrecommittedState<E> {
-  fn rerandomize(&self, ck: &CommitmentKey<E>, S: &SplitR1CSShape<E>) -> Result<Self, SpartanError>
+  fn rerandomize(&self, ck: &CommitmentKey<E>, S: &SplitR1CSShape<E>) -> Result<Self, VegaError>
   where
     Self: Sized,
   {
@@ -553,7 +553,7 @@ impl<E: Engine> RerandomizationTrait<E> for PrecommittedState<E> {
     S: &SplitR1CSShape<E>,
     comm_W_shared: &Option<Commitment<E>>,
     r_W_shared: &Option<Blind<E>>,
-  ) -> Result<Self, SpartanError>
+  ) -> Result<Self, VegaError>
   where
     Self: Sized,
   {
@@ -569,7 +569,7 @@ impl<E: Engine> PrecommittedState<E> {
     &mut self,
     ck: &CommitmentKey<E>,
     S: &SplitR1CSShape<E>,
-  ) -> Result<(), SpartanError> {
+  ) -> Result<(), VegaError> {
     if let (Some(comm), Some(r_old)) = (&self.comm_W_shared, &self.r_W_shared) {
       let r_new = PCS::<E>::blind(ck, S.num_shared);
       self.comm_W_shared = Some(PCS::<E>::rerandomize_commitment(ck, comm, r_old, &r_new)?);
@@ -590,7 +590,7 @@ impl<E: Engine> PrecommittedState<E> {
     S: &SplitR1CSShape<E>,
     comm_W_shared: &Option<Commitment<E>>,
     r_W_shared: &Option<Blind<E>>,
-  ) -> Result<(), SpartanError> {
+  ) -> Result<(), VegaError> {
     self.comm_W_shared = comm_W_shared.clone();
     self.r_W_shared = r_W_shared.clone();
     if let (Some(comm), Some(r_old)) = (&self.comm_W_precommitted, &self.r_W_precommitted) {
@@ -602,7 +602,7 @@ impl<E: Engine> PrecommittedState<E> {
   }
 }
 
-impl<E: Engine> MultiRoundSpartanShape<E> for ShapeCS<E> {
+impl<E: Engine> MultiRoundVegaShape<E> for ShapeCS<E> {
   fn multiround_r1cs_shape<C: MultiRoundCircuit<E>>(
     circuit: &C,
   ) -> Result<
@@ -611,7 +611,7 @@ impl<E: Engine> MultiRoundSpartanShape<E> for ShapeCS<E> {
       CommitmentKey<E>,
       VerifierKey<E>,
     ),
-    SpartanError,
+    VegaError,
   > {
     let num_rounds = circuit.num_rounds();
     let mut cs: Self = Self::new();
@@ -627,7 +627,7 @@ impl<E: Engine> MultiRoundSpartanShape<E> for ShapeCS<E> {
       let num_challenges =
         circuit
           .num_challenges(round)
-          .map_err(|e| SpartanError::SynthesisError {
+          .map_err(|e| VegaError::SynthesisError {
             reason: format!("Unable to get num_challenges for round {round}: {e}"),
           })?;
       num_challenges_per_round.push(num_challenges);
@@ -636,7 +636,7 @@ impl<E: Engine> MultiRoundSpartanShape<E> for ShapeCS<E> {
       let prev_aux = cs.num_aux();
       let (round_vars, round_challenges) = circuit
         .rounds(&mut cs, round, &vars_per_round, &challenges_per_round, None)
-        .map_err(|e| SpartanError::SynthesisError {
+        .map_err(|e| VegaError::SynthesisError {
           reason: format!("Unable to synthesize round {round}: {e}"),
         })?;
 
@@ -709,12 +709,12 @@ pub struct MultiRoundState<E: Engine> {
   num_rounds: usize,
 }
 
-impl<E: Engine> MultiRoundSpartanWitness<E> for SatisfyingAssignment<E> {
+impl<E: Engine> MultiRoundVegaWitness<E> for SatisfyingAssignment<E> {
   type MultiRoundState = MultiRoundState<E>;
 
   fn initialize_multiround_witness(
     s: &SplitMultiRoundR1CSShape<E>,
-  ) -> Result<Self::MultiRoundState, SpartanError> {
+  ) -> Result<Self::MultiRoundState, VegaError> {
     let cs = Self::new();
     let total_vars: usize = s.num_vars_per_round.iter().sum();
     let w = vec![E::Scalar::ZERO; total_vars];
@@ -739,9 +739,9 @@ impl<E: Engine> MultiRoundSpartanWitness<E> for SatisfyingAssignment<E> {
     circuit: &C,
     round_index: usize,
     transcript: &mut E::TE,
-  ) -> Result<Vec<E::Scalar>, SpartanError> {
+  ) -> Result<Vec<E::Scalar>, VegaError> {
     if round_index != state.current_round {
-      return Err(SpartanError::SynthesisError {
+      return Err(VegaError::SynthesisError {
         reason: format!(
           "Expected round {}, got {}",
           state.current_round, round_index
@@ -764,7 +764,7 @@ impl<E: Engine> MultiRoundSpartanWitness<E> for SatisfyingAssignment<E> {
         &state.challenges_per_round,
         chals,
       )
-      .map_err(|e| SpartanError::SynthesisError {
+      .map_err(|e| VegaError::SynthesisError {
         reason: format!("Unable to synthesize round {round_index}: {e}"),
       })?;
 
@@ -802,7 +802,7 @@ impl<E: Engine> MultiRoundSpartanWitness<E> for SatisfyingAssignment<E> {
     // Generate challenges for this round
     let challenges = (0..s.num_challenges_per_round[round_index])
       .map(|_| transcript.squeeze(b"challenge"))
-      .collect::<Result<Vec<E::Scalar>, SpartanError>>()?;
+      .collect::<Result<Vec<E::Scalar>, VegaError>>()?;
 
     state.vars_per_round.push(round_vars);
     state.challenges_per_round.push(round_challenges);
@@ -818,9 +818,9 @@ impl<E: Engine> MultiRoundSpartanWitness<E> for SatisfyingAssignment<E> {
   fn finalize_multiround_witness(
     state: &mut Self::MultiRoundState,
     s: &SplitMultiRoundR1CSShape<E>,
-  ) -> Result<(SplitMultiRoundR1CSInstance<E>, R1CSWitness<E>), SpartanError> {
+  ) -> Result<(SplitMultiRoundR1CSInstance<E>, R1CSWitness<E>), VegaError> {
     if state.current_round != state.num_rounds {
-      return Err(SpartanError::SynthesisError {
+      return Err(VegaError::SynthesisError {
         reason: format!(
           "Expected {} rounds, processed {}",
           state.num_rounds, state.current_round

--- a/src/bellpepper/shape_cs.rs
+++ b/src/bellpepper/shape_cs.rs
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
-// This file is part of the Spartan2 project.
+// This file is part of the vega-prover project.
 // See the LICENSE file in the project root for full license information.
-// Source repository: https://github.com/Microsoft/Spartan2
+// Source repository: https://github.com/Microsoft/vega-prover
 
 //! Support for generating R1CS shape using bellperson.
 

--- a/src/bellpepper/solver.rs
+++ b/src/bellpepper/solver.rs
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
-// This file is part of the Spartan2 project.
+// This file is part of the vega-prover project.
 // See the LICENSE file in the project root for full license information.
-// Source repository: https://github.com/Microsoft/Spartan2
+// Source repository: https://github.com/Microsoft/vega-prover
 
 //! Support for generating R1CS witness using bellpepper.
 use crate::traits::Engine;

--- a/src/bellpepper/test_r1cs.rs
+++ b/src/bellpepper/test_r1cs.rs
@@ -1,44 +1,40 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
-// This file is part of the Spartan2 project.
+// This file is part of the vega-prover project.
 // See the LICENSE file in the project root for full license information.
-// Source repository: https://github.com/Microsoft/Spartan2
+// Source repository: https://github.com/Microsoft/vega-prover
 
 //! This module supports generating R1CS instance-witness pairs for test constraint systems.
 //! This currently does not support generating split R1CS instances, but it can be extended to do so.
 use crate::{
   CommitmentKey, VerifierKey,
   bellpepper::{r1cs::add_constraint, solver::SatisfyingAssignment, test_shape_cs::TestShapeCS},
-  errors::SpartanError,
+  errors::VegaError,
   r1cs::{R1CSInstance, R1CSShape, R1CSWitness, SparseMatrix},
   start_span,
   traits::Engine,
 };
 use tracing::info;
 
-/// `TestSpartanShape` provides methods for acquiring `R1CSShape` and `CommitmentKey` from implementers.
-pub trait TestSpartanShape<E: Engine> {
+/// `TestVegaShape` provides methods for acquiring `R1CSShape` and `CommitmentKey` from implementers.
+pub trait TestVegaShape<E: Engine> {
   /// Return an appropriate `R1CSShape` and `CommitmentKey` structs.
-  fn r1cs_shape(
-    &mut self,
-  ) -> Result<(R1CSShape<E>, CommitmentKey<E>, VerifierKey<E>), SpartanError>;
+  fn r1cs_shape(&mut self) -> Result<(R1CSShape<E>, CommitmentKey<E>, VerifierKey<E>), VegaError>;
 }
 
-/// `TestSpartanWitness` provide a method for acquiring an `R1CSInstance` and `R1CSWitness` from implementers.
-pub trait TestSpartanWitness<E: Engine> {
+/// `TestVegaWitness` provide a method for acquiring an `R1CSInstance` and `R1CSWitness` from implementers.
+pub trait TestVegaWitness<E: Engine> {
   /// Return an instance and witness, given a shape and ck.
   fn r1cs_instance_and_witness(
     &mut self,
     S: &R1CSShape<E>,
     ck: &CommitmentKey<E>,
     is_small: bool,
-  ) -> Result<(R1CSInstance<E>, R1CSWitness<E>), SpartanError>;
+  ) -> Result<(R1CSInstance<E>, R1CSWitness<E>), VegaError>;
 }
 
-impl<E: Engine> TestSpartanShape<E> for TestShapeCS<E> {
-  fn r1cs_shape(
-    &mut self,
-  ) -> Result<(R1CSShape<E>, CommitmentKey<E>, VerifierKey<E>), SpartanError> {
+impl<E: Engine> TestVegaShape<E> for TestShapeCS<E> {
+  fn r1cs_shape(&mut self) -> Result<(R1CSShape<E>, CommitmentKey<E>, VerifierKey<E>), VegaError> {
     let mut A = SparseMatrix::<E::Scalar>::empty();
     let mut B = SparseMatrix::<E::Scalar>::empty();
     let mut C = SparseMatrix::<E::Scalar>::empty();
@@ -72,13 +68,13 @@ impl<E: Engine> TestSpartanShape<E> for TestShapeCS<E> {
   }
 }
 
-impl<E: Engine> TestSpartanWitness<E> for SatisfyingAssignment<E> {
+impl<E: Engine> TestVegaWitness<E> for SatisfyingAssignment<E> {
   fn r1cs_instance_and_witness(
     &mut self,
     shape: &R1CSShape<E>,
     ck: &CommitmentKey<E>,
     is_small: bool,
-  ) -> Result<(R1CSInstance<E>, R1CSWitness<E>), SpartanError> {
+  ) -> Result<(R1CSInstance<E>, R1CSWitness<E>), VegaError> {
     let (_witness_span, witness_t) = start_span!("create_r1cs_witness");
     let (W, comm_W) = R1CSWitness::<E>::new(ck, shape, &mut self.aux_assignment, is_small)?;
     info!(elapsed_ms = %witness_t.elapsed().as_millis(), "create_r1cs_witness");

--- a/src/bellpepper/test_shape_cs.rs
+++ b/src/bellpepper/test_shape_cs.rs
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
-// This file is part of the Spartan2 project.
+// This file is part of the vega-prover project.
 // See the LICENSE file in the project root for full license information.
-// Source repository: https://github.com/Microsoft/Spartan2
+// Source repository: https://github.com/Microsoft/vega-prover
 
 //! Support for generating R1CS shape using bellpepper.
 //! `TestShapeCS` implements a superset of `ShapeCS`, adding non-trivial namespace support for use in testing.

--- a/src/digest.rs
+++ b/src/digest.rs
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
-// This file is part of the Spartan2 project.
+// This file is part of the vega-prover project.
 // See the LICENSE file in the project root for full license information.
-// Source repository: https://github.com/Microsoft/Spartan2
+// Source repository: https://github.com/Microsoft/vega-prover
 
 //! Cryptographic digest functionality for Spartan.
 //!
@@ -12,7 +12,7 @@
 //! marker trait for serializable types, and the `DigestComputer` utility for
 //! computing SHA-256 digests.
 
-use crate::traits::snark::SpartanDigest;
+use crate::traits::snark::VegaDigest;
 use bincode::Options;
 use serde::Serialize;
 use sha2::{Digest, Sha256};
@@ -61,7 +61,7 @@ impl<'a, T: Digestible> DigestComputer<'a, T> {
   }
 
   /// Compute the digest of a `Digestible` instance.
-  pub fn digest(&self) -> Result<SpartanDigest, io::Error> {
+  pub fn digest(&self) -> Result<VegaDigest, io::Error> {
     // Stream bytes directly into the hasher via a small buffered adapter.
     // A 64 KiB buffer is large enough to amortize per-call overhead from
     // bincode while avoiding the large upfront allocation that a

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,16 +1,16 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
-// This file is part of the Spartan2 project.
+// This file is part of the vega-prover project.
 // See the LICENSE file in the project root for full license information.
-// Source repository: https://github.com/Microsoft/Spartan2
+// Source repository: https://github.com/Microsoft/vega-prover
 
 //! This module defines errors returned by the library.
 use core::fmt::Debug;
 use thiserror::Error;
 
-/// Errors returned by Spartan2
+/// Errors returned by vega-prover
 #[derive(Clone, Debug, Eq, PartialEq, Error)]
-pub enum SpartanError {
+pub enum VegaError {
   /// returned if the supplied row or col in (row,col,val) tuple is out of range
   #[error("InvalidIndex")]
   InvalidIndex,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,12 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
-// This file is part of the Spartan2 project.
+// This file is part of the vega-prover project.
 // See the LICENSE file in the project root for full license information.
-// Source repository: https://github.com/Microsoft/Spartan2
+// Source repository: https://github.com/Microsoft/vega-prover
 
-//! This library implements Spartan, a high-speed SNARK.
-//! We currently implement a non-preprocessing version of Spartan
-//! that is generic over the polynomial commitment and evaluation argument (i.e., a PCS).
+//! This library implements the ZK provers of Vega, optimized for low-latency
+//! client-side proving of statements over signed data.
 #![deny(
   warnings,
   unused,
@@ -43,10 +42,10 @@ mod polys;
 mod sumcheck;
 
 // public modules for proof systems
-pub mod neutronnova_zk; // NeutronNova with zero-knowledge
-pub mod spartan; // Spartan without zero-knowledge
-pub mod spartan_relaxed; // Spartan for relaxed R1CS (non-ZK)
-pub mod spartan_zk; // Spartan with zero-knowledge
+pub mod spartan_relaxed; // single-circuit prover for relaxed R1CS (non-ZK)
+pub mod vega_mc_zkp; // multi-circuit (NeutronNova folding) prover with zero-knowledge
+pub mod vega_sc; // single-circuit (Spartan) prover without zero-knowledge
+pub mod vega_sc_zkp; // single-circuit (Spartan) prover with zero-knowledge
 
 /// Start a span + timer, return `(Span, Instant)`.
 macro_rules! start_span {

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,13 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
-// This file is part of the Spartan2 project.
+// This file is part of the vega-prover project.
 // See the LICENSE file in the project root for full license information.
-// Source repository: https://github.com/Microsoft/Spartan2
+// Source repository: https://github.com/Microsoft/vega-prover
 
 /// Macros to give syntactic sugar for zipWith pattern and variants.
 ///
 /// ```ignore
-/// use crate::spartan::zip_with;
+/// use crate::vega_sc::zip_with;
 /// use itertools::Itertools as _; // we use zip_eq to zip!
 /// let v = vec![0, 1, 2];
 /// let w = vec![2, 3, 4];

--- a/src/math.rs
+++ b/src/math.rs
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
-// This file is part of the Spartan2 project.
+// This file is part of the vega-prover project.
 // See the LICENSE file in the project root for full license information.
-// Source repository: https://github.com/Microsoft/Spartan2
+// Source repository: https://github.com/Microsoft/vega-prover
 
 //! Mathematical utility functions for Spartan.
 //!

--- a/src/nifs.rs
+++ b/src/nifs.rs
@@ -1,13 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
-// This file is part of the Spartan2 project.
+// This file is part of the vega-prover project.
 // See the LICENSE file in the project root for full license information.
-// Source repository: https://github.com/Microsoft/Spartan2
+// Source repository: https://github.com/Microsoft/vega-prover
 
 //! Nova's non-Interactive Folding Scheme (NIFS)
 use crate::{
   Blind, Commitment, CommitmentKey, PCS,
-  errors::SpartanError,
+  errors::VegaError,
   r1cs::{R1CSInstance, R1CSShape, R1CSWitness, RelaxedR1CSInstance, RelaxedR1CSWitness},
   traits::{
     Engine,
@@ -39,7 +39,7 @@ where
     U2: &R1CSInstance<E>,
     W2: &R1CSWitness<E>,
     transcript: &mut E::TE,
-  ) -> Result<(Self, RelaxedR1CSWitness<E>, E::Scalar, Vec<E::Scalar>), SpartanError> {
+  ) -> Result<(Self, RelaxedR1CSWitness<E>, E::Scalar, Vec<E::Scalar>), VegaError> {
     // Use the caller-provided transcript and absorb both instances.
     transcript.absorb(b"U1", U1);
     transcript.absorb(b"U2", U2);
@@ -67,7 +67,7 @@ where
     transcript: &mut E::TE,
     U1: &RelaxedR1CSInstance<E>,
     U2: &R1CSInstance<E>,
-  ) -> Result<RelaxedR1CSInstance<E>, SpartanError> {
+  ) -> Result<RelaxedR1CSInstance<E>, VegaError> {
     transcript.absorb(b"U1", U1);
     transcript.absorb(b"U2", U2);
     transcript.absorb(b"comm_T", &self.comm_T);

--- a/src/polys/eq.rs
+++ b/src/polys/eq.rs
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
-// This file is part of the Spartan2 project.
+// This file is part of the vega-prover project.
 // See the LICENSE file in the project root for full license information.
-// Source repository: https://github.com/Microsoft/Spartan2
+// Source repository: https://github.com/Microsoft/vega-prover
 
 //! `EqPolynomial`: Represents multilinear extension of equality polynomials, evaluated based on binary input values.
 use ff::PrimeField;

--- a/src/polys/mod.rs
+++ b/src/polys/mod.rs
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
-// This file is part of the Spartan2 project.
+// This file is part of the vega-prover project.
 // See the LICENSE file in the project root for full license information.
-// Source repository: https://github.com/Microsoft/Spartan2
+// Source repository: https://github.com/Microsoft/vega-prover
 
 //! This module contains the definitions of polynomial types used in the Spartan SNARK.
 pub mod eq;

--- a/src/polys/multilinear.rs
+++ b/src/polys/multilinear.rs
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
-// This file is part of the Spartan2 project.
+// This file is part of the vega-prover project.
 // See the LICENSE file in the project root for full license information.
-// Source repository: https://github.com/Microsoft/Spartan2
+// Source repository: https://github.com/Microsoft/vega-prover
 
 //! Main components:
 //! - `MultilinearPolynomial`: Dense representation of multilinear polynomials, represented by evaluations over all possible binary inputs.

--- a/src/polys/power.rs
+++ b/src/polys/power.rs
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
-// This file is part of the Spartan2 project.
+// This file is part of the vega-prover project.
 // See the LICENSE file in the project root for full license information.
-// Source repository: https://github.com/Microsoft/Spartan2
+// Source repository: https://github.com/Microsoft/vega-prover
 
 //! `PowPolynomial`: Represents multilinear extension of power polynomials
-use crate::errors::SpartanError;
+use crate::errors::VegaError;
 use core::iter::successors;
 use ff::PrimeField;
 
@@ -31,9 +31,9 @@ impl<Scalar: PrimeField> PowPolynomial<Scalar> {
   }
 
   /// Evaluates the polynomial at a given point `r`.
-  pub fn evaluate(&self, r: &[Scalar]) -> Result<Scalar, SpartanError> {
+  pub fn evaluate(&self, r: &[Scalar]) -> Result<Scalar, VegaError> {
     if r.len() != self.t_pow.len() {
-      return Err(SpartanError::InvalidInputLength {
+      return Err(VegaError::InvalidInputLength {
         reason: format!(
           "PowPolynomial: Expected {} elements in r, got {}",
           self.t_pow.len(),

--- a/src/polys/univariate.rs
+++ b/src/polys/univariate.rs
@@ -1,14 +1,14 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
-// This file is part of the Spartan2 project.
+// This file is part of the vega-prover project.
 // See the LICENSE file in the project root for full license information.
-// Source repository: https://github.com/Microsoft/Spartan2
+// Source repository: https://github.com/Microsoft/vega-prover
 
 //! Main components:
 //! - `UniPoly`: an univariate dense polynomial in coefficient form (big endian),
 //! - `CompressedUniPoly`: a univariate dense polynomial, compressed (omitted linear term), in coefficient form (little endian),
 use crate::{
-  errors::SpartanError,
+  errors::VegaError,
   traits::{Group, transcript::TranscriptReprTrait},
 };
 use ff::PrimeField;
@@ -44,9 +44,9 @@ impl<Scalar: PrimeField> UniPoly<Scalar> {
   /// using Gaussian elimination.
   ///
   /// # Errors
-  /// Returns `SpartanError` if the Gaussian elimination fails due to singular matrix
+  /// Returns `VegaError` if the Gaussian elimination fails due to singular matrix
   /// or invalid input dimensions.
-  pub fn from_evals(evals: &[Scalar]) -> Result<Self, SpartanError> {
+  pub fn from_evals(evals: &[Scalar]) -> Result<Self, VegaError> {
     // Use closed-form formulas for common degrees to avoid Gaussian elimination
     match evals.len() {
       3 => Ok(Self::from_evals_deg2(evals)),
@@ -204,11 +204,11 @@ impl<G: Group> TranscriptReprTrait<G> for UniPoly<G::Scalar> {
 /// A vector containing the solution (polynomial coefficients), or an error if the system cannot be solved.
 ///
 /// # Errors
-/// Returns `SpartanError::DivisionByZero` if any diagonal element is zero during the solving process.
-pub fn gaussian_elimination<F: PrimeField>(matrix: &mut [Vec<F>]) -> Result<Vec<F>, SpartanError> {
+/// Returns `VegaError::DivisionByZero` if any diagonal element is zero during the solving process.
+pub fn gaussian_elimination<F: PrimeField>(matrix: &mut [Vec<F>]) -> Result<Vec<F>, VegaError> {
   let size = matrix.len();
   if size != matrix[0].len() - 1 {
-    return Err(SpartanError::InvalidInputLength {
+    return Err(VegaError::InvalidInputLength {
       reason: format!(
         "Gaussian elimination: Expected a square matrix, got {} rows and {} columns",
         size,
@@ -232,7 +232,7 @@ pub fn gaussian_elimination<F: PrimeField>(matrix: &mut [Vec<F>]) -> Result<Vec<
   #[allow(clippy::needless_range_loop)]
   for i in 0..size {
     if matrix[i][i] == F::ZERO {
-      return Err(SpartanError::DivisionByZero);
+      return Err(VegaError::DivisionByZero);
     }
   }
 
@@ -244,7 +244,7 @@ pub fn gaussian_elimination<F: PrimeField>(matrix: &mut [Vec<F>]) -> Result<Vec<
   Ok(result)
 }
 
-fn echelon<F: PrimeField>(matrix: &mut [Vec<F>], i: usize, j: usize) -> Result<(), SpartanError> {
+fn echelon<F: PrimeField>(matrix: &mut [Vec<F>], i: usize, j: usize) -> Result<(), VegaError> {
   let size = matrix.len();
   if matrix[i][i] != F::ZERO {
     let factor = div_f(matrix[j + 1][i], matrix[i][i])?;
@@ -256,7 +256,7 @@ fn echelon<F: PrimeField>(matrix: &mut [Vec<F>], i: usize, j: usize) -> Result<(
   Ok(())
 }
 
-fn eliminate<F: PrimeField>(matrix: &mut [Vec<F>], i: usize) -> Result<(), SpartanError> {
+fn eliminate<F: PrimeField>(matrix: &mut [Vec<F>], i: usize) -> Result<(), VegaError> {
   let size = matrix.len();
   if matrix[i][i] != F::ZERO {
     for j in (1..i + 1).rev() {
@@ -280,13 +280,13 @@ fn eliminate<F: PrimeField>(matrix: &mut [Vec<F>], i: usize) -> Result<(), Spart
 /// The result of `a / b` or an error if `b` is zero
 ///
 /// # Errors
-/// Returns `SpartanError::DivisionByZero` if `b` is zero (not invertible).
-pub fn div_f<F: PrimeField>(a: F, b: F) -> Result<F, SpartanError> {
+/// Returns `VegaError::DivisionByZero` if `b` is zero (not invertible).
+pub fn div_f<F: PrimeField>(a: F, b: F) -> Result<F, VegaError> {
   let inverse_b = b.invert();
 
   match inverse_b.into_option() {
     Some(inv) => Ok(a * inv),
-    None => Err(SpartanError::DivisionByZero),
+    None => Err(VegaError::DivisionByZero),
   }
 }
 

--- a/src/provider/bn254.rs
+++ b/src/provider/bn254.rs
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
-// This file is part of the Spartan2 project.
+// This file is part of the vega-prover project.
 // See the LICENSE file in the project root for full license information.
-// Source repository: https://github.com/Microsoft/Spartan2
+// Source repository: https://github.com/Microsoft/vega-prover
 
 //! This module implements the Spartan traits for BN254 (also known as BN256 or alt_bn128).
 use crate::{

--- a/src/provider/keccak.rs
+++ b/src/provider/keccak.rs
@@ -1,12 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
-// This file is part of the Spartan2 project.
+// This file is part of the vega-prover project.
 // See the LICENSE file in the project root for full license information.
-// Source repository: https://github.com/Microsoft/Spartan2
+// Source repository: https://github.com/Microsoft/vega-prover
 
 //! This module provides an implementation of `TranscriptEngineTrait` using keccak256
 use crate::{
-  errors::SpartanError,
+  errors::VegaError,
   traits::{
     Engine, PrimeFieldExt,
     transcript::{TranscriptEngineTrait, TranscriptReprTrait},
@@ -67,7 +67,7 @@ impl<E: Engine> TranscriptEngineTrait<E> for Keccak256Transcript<E> {
     }
   }
 
-  fn squeeze(&mut self, label: &'static [u8]) -> Result<E::Scalar, SpartanError> {
+  fn squeeze(&mut self, label: &'static [u8]) -> Result<E::Scalar, VegaError> {
     // we gather the full input from the round, preceded by the current state of the transcript
     let input = [
       DOM_SEP_TAG,
@@ -83,7 +83,7 @@ impl<E: Engine> TranscriptEngineTrait<E> for Keccak256Transcript<E> {
       if let Some(v) = self.round.checked_add(1) {
         v
       } else {
-        return Err(SpartanError::InternalTranscriptError);
+        return Err(VegaError::InternalTranscriptError);
       }
     };
     self.state.copy_from_slice(&output);

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
-// This file is part of the Spartan2 project.
+// This file is part of the vega-prover project.
 // See the LICENSE file in the project root for full license information.
-// Source repository: https://github.com/Microsoft/Spartan2
+// Source repository: https://github.com/Microsoft/vega-prover
 
 //! This module implements Spartan's traits using the following several different combinations
 

--- a/src/provider/msm.rs
+++ b/src/provider/msm.rs
@@ -1,14 +1,14 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
-// This file is part of the Spartan2 project.
+// This file is part of the vega-prover project.
 // See the LICENSE file in the project root for full license information.
-// Source repository: https://github.com/Microsoft/Spartan2
+// Source repository: https://github.com/Microsoft/vega-prover
 
 //! This module provides a multi-scalar multiplication routine
 //! The generic implementation is adapted from halo2; we add an optimization to commit to bits more efficiently
 //! The specialized implementations are adapted from jolt, with additional optimizations and parallelization.
 use crate::{
-  errors::SpartanError,
+  errors::VegaError,
   provider::traits::{DlogGroup, DlogGroupExt},
   start_span,
   traits::Engine,
@@ -183,16 +183,16 @@ fn cpu_msm_serial<C: CurveAffine>(coeffs: &[C::Scalar], bases: &[C]) -> C::Curve
 /// Adapted from zcash/halo2
 ///
 /// # Errors
-/// Returns `SpartanError::InvalidInputLength` if coeffs and bases have different lengths.
+/// Returns `VegaError::InvalidInputLength` if coeffs and bases have different lengths.
 pub fn msm<C: CurveAffine>(
   coeffs: &[C::Scalar],
   bases: &[C],
   use_parallelism_internally: bool,
-) -> Result<C::Curve, SpartanError> {
+) -> Result<C::Curve, VegaError> {
   let (_msm_span, msm_t) = start_span!("msm", size = coeffs.len());
 
   if coeffs.len() != bases.len() {
-    return Err(SpartanError::InvalidInputLength {
+    return Err(VegaError::InvalidInputLength {
       reason: "MSM: Coefficients and bases must have the same length".to_string(),
     });
   }
@@ -228,7 +228,7 @@ pub fn msm<C: CurveAffine>(
 pub fn msm_shared_weights<C: CurveAffine>(
   weights: &[C::Scalar],
   bases_rows: &[&[C]],
-) -> Result<Vec<C::Curve>, SpartanError> {
+) -> Result<Vec<C::Curve>, VegaError> {
   let n = weights.len();
   if n == 0 || bases_rows.is_empty() {
     return Ok(vec![C::Curve::identity(); bases_rows.len()]);
@@ -362,25 +362,25 @@ fn num_bits(n: usize) -> usize {
 /// Multi-scalar multiplication using the best algorithm for the given scalars.
 ///
 /// # Errors
-/// Returns `SpartanError::InvalidInputLength` if bases and scalars have different lengths.
-/// Returns `SpartanError::InternalError` if scalars contain values that cannot be processed.
+/// Returns `VegaError::InvalidInputLength` if bases and scalars have different lengths.
+/// Returns `VegaError::InternalError` if scalars contain values that cannot be processed.
 pub fn msm_small<C: CurveAffine, T: Integer + Into<u64> + Copy + Sync + ToPrimitive>(
   scalars: &[T],
   bases: &[C],
   use_parallelism_internally: bool,
-) -> Result<C::Curve, SpartanError> {
+) -> Result<C::Curve, VegaError> {
   let (_msm_small_span, msm_small_t) = start_span!("msm_small", size = scalars.len());
 
   if bases.len() != scalars.len() {
-    return Err(SpartanError::InvalidInputLength {
+    return Err(VegaError::InvalidInputLength {
       reason: "MSM Small: Coefficients and bases must have the same length".to_string(),
     });
   }
 
-  let max_scalar = scalars.iter().max().ok_or(SpartanError::InternalError {
+  let max_scalar = scalars.iter().max().ok_or(VegaError::InternalError {
     reason: "Unable to find maximum value".to_string(),
   })?;
-  let max_scalar_usize = max_scalar.to_usize().ok_or(SpartanError::InternalError {
+  let max_scalar_usize = max_scalar.to_usize().ok_or(VegaError::InternalError {
     reason: "Unable to convert maximum value to usize".to_string(),
   })?;
   let max_num_bits = num_bits(max_scalar_usize);

--- a/src/provider/pasta.rs
+++ b/src/provider/pasta.rs
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
-// This file is part of the Spartan2 project.
+// This file is part of the vega-prover project.
 // See the LICENSE file in the project root for full license information.
-// Source repository: https://github.com/Microsoft/Spartan2
+// Source repository: https://github.com/Microsoft/vega-prover
 
 //! This module implements the Spartan traits for `pallas::Point`, `pallas::Scalar`, `vesta::Point`, `vesta::Scalar`.
 use crate::{

--- a/src/provider/pcs/hyrax_pc.rs
+++ b/src/provider/pcs/hyrax_pc.rs
@@ -1,12 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
-// This file is part of the Spartan2 project.
+// This file is part of the vega-prover project.
 // See the LICENSE file in the project root for full license information.
-// Source repository: https://github.com/Microsoft/Spartan2
+// Source repository: https://github.com/Microsoft/vega-prover
 
 //! This module implements the Hyrax polynomial commitment scheme
 use crate::{
-  errors::SpartanError,
+  errors::VegaError,
   math::Math,
   polys::eq::EqPolynomial,
   provider::{
@@ -209,7 +209,7 @@ where
     v: &[E::Scalar],
     r: &Self::Blind,
     is_small: bool,
-  ) -> Result<Self::Commitment, SpartanError> {
+  ) -> Result<Self::Commitment, VegaError> {
     let n = v.len();
 
     // compute the expected number of columns
@@ -306,7 +306,7 @@ where
     ck: &Self::CommitmentKey,
     n: usize,
     r: &Self::Blind,
-  ) -> Result<Self::Commitment, SpartanError> {
+  ) -> Result<Self::Commitment, VegaError> {
     let num_cols = ck.num_cols;
     let num_rows = div_ceil(n, num_cols);
     let h_table = ck
@@ -323,9 +323,9 @@ where
     comm: &Self::Commitment,
     r_old: &Self::Blind,
     r_new: &Self::Blind,
-  ) -> Result<Self::Commitment, SpartanError> {
+  ) -> Result<Self::Commitment, VegaError> {
     if comm.comm.len() != r_old.blind.len() || comm.comm.len() != r_new.blind.len() {
-      return Err(SpartanError::InvalidInputLength {
+      return Err(VegaError::InvalidInputLength {
         reason: "rerandomize_commitment: commitment and blinds must have the same length"
           .to_string(),
       });
@@ -343,10 +343,10 @@ where
     Ok(HyraxCommitment { comm: new_comm })
   }
 
-  fn check_commitment(comm: &Self::Commitment, n: usize, width: usize) -> Result<(), SpartanError> {
+  fn check_commitment(comm: &Self::Commitment, n: usize, width: usize) -> Result<(), VegaError> {
     let min_rows = div_ceil(n, width);
     if comm.comm.len() != min_rows {
-      return Err(SpartanError::InvalidCommitmentLength {
+      return Err(VegaError::InvalidCommitmentLength {
         reason: format!(
           "InvalidCommitmentLength: actual: {}, expected: {}",
           comm.comm.len(),
@@ -357,9 +357,9 @@ where
     Ok(())
   }
 
-  fn combine_commitments(comms: &[Self::Commitment]) -> Result<Self::Commitment, SpartanError> {
+  fn combine_commitments(comms: &[Self::Commitment]) -> Result<Self::Commitment, VegaError> {
     if comms.is_empty() {
-      return Err(SpartanError::InvalidInputLength {
+      return Err(VegaError::InvalidInputLength {
         reason: "combine_commitments: No commitments provided".to_string(),
       });
     }
@@ -371,9 +371,9 @@ where
     Ok(HyraxCommitment { comm })
   }
 
-  fn combine_blinds(blinds: &[Self::Blind]) -> Result<Self::Blind, SpartanError> {
+  fn combine_blinds(blinds: &[Self::Blind]) -> Result<Self::Blind, VegaError> {
     if blinds.is_empty() {
-      return Err(SpartanError::InvalidInputLength {
+      return Err(VegaError::InvalidInputLength {
         reason: "combine_blinds: No blinds provided".to_string(),
       });
     }
@@ -394,11 +394,11 @@ where
     point: &[E::Scalar],
     comm_eval: &Self::Commitment,
     blind_eval: &Self::Blind,
-  ) -> Result<Self::EvaluationArgument, SpartanError> {
+  ) -> Result<Self::EvaluationArgument, VegaError> {
     let n = poly.len();
     let (_setup_span, setup_t) = start_span!("hyrax_prove_prep");
     if n != (2usize).pow(point.len() as u32) {
-      return Err(SpartanError::InvalidInputLength {
+      return Err(VegaError::InvalidInputLength {
         reason: format!(
           "Hyrax prove: Expected {} elements in poly, got {}",
           (2_usize).pow(point.len() as u32),
@@ -485,7 +485,7 @@ where
     point: &[E::Scalar],
     comm_eval: &Self::Commitment,
     arg: &Self::EvaluationArgument,
-  ) -> Result<(), SpartanError> {
+  ) -> Result<(), VegaError> {
     let (_verify_span, verify_t) = start_span!("hyrax_pcs_verify");
     transcript.absorb(b"poly_com", comm);
 
@@ -534,7 +534,7 @@ where
     ck: &Self::CommitmentKey,
     v: &[E::Scalar],
     is_small: bool,
-  ) -> Result<Vec<E::GE>, SpartanError> {
+  ) -> Result<Vec<E::GE>, VegaError> {
     use ff::Field;
     let n = v.len();
     let num_cols = ck.ck.len();
@@ -571,7 +571,7 @@ where
     raw: &[E::GE],
     delta: &[E::Scalar],
     blind: &Self::Blind,
-  ) -> Result<Self::Commitment, SpartanError> {
+  ) -> Result<Self::Commitment, VegaError> {
     use ff::Field;
     let num_cols = ck.ck.len();
     let n = delta.len();
@@ -580,7 +580,7 @@ where
       .h_table
       .get_or_init(|| FixedBaseMul::precompute(&ck.h, 8));
 
-    let comm: Result<Vec<E::GE>, SpartanError> = (0..num_rows)
+    let comm: Result<Vec<E::GE>, VegaError> = (0..num_rows)
       .into_par_iter()
       .map(|i| {
         let row_start = i * num_cols;
@@ -611,7 +611,7 @@ where
     poly: &[E::Scalar],
     blind: &Self::Blind,
     point: &[E::Scalar],
-  ) -> Result<(Vec<E::Scalar>, E::Scalar), SpartanError> {
+  ) -> Result<(Vec<E::Scalar>, E::Scalar), VegaError> {
     let num_cols = ck.num_cols;
     // Derive dimensions from point length (must match how commitment was structured)
     let n = (2_usize).pow(point.len() as u32);
@@ -657,10 +657,10 @@ where
     v: &[E::Scalar],
     combined_blind: &E::Scalar,
     point: &[E::Scalar],
-  ) -> Result<E::Scalar, SpartanError> {
+  ) -> Result<E::Scalar, VegaError> {
     let num_cols = vk.num_cols;
     if v.len() != num_cols {
-      return Err(SpartanError::ProofVerifyError {
+      return Err(VegaError::ProofVerifyError {
         reason: format!(
           "Direct opening: v.len() ({}) != num_cols ({})",
           v.len(),
@@ -693,7 +693,7 @@ where
       E::GE::vartime_multiscalar_mul(v, &vk.ck[..v.len()], false)? + vk.h * *combined_blind;
 
     if comm_LZ != expected {
-      return Err(SpartanError::ProofVerifyError {
+      return Err(VegaError::ProofVerifyError {
         reason: "Direct opening: commitment mismatch".to_string(),
       });
     }
@@ -737,9 +737,9 @@ where
   fn fold_commitments(
     comms: &[Self::Commitment],
     weights: &[E::Scalar],
-  ) -> Result<Self::Commitment, SpartanError> {
+  ) -> Result<Self::Commitment, VegaError> {
     if comms.is_empty() || weights.is_empty() || comms.len() != weights.len() {
-      return Err(SpartanError::InvalidInputLength {
+      return Err(VegaError::InvalidInputLength {
         reason: "fold_commitments: Commitments and weights must have the same length".to_string(),
       });
     }
@@ -747,7 +747,7 @@ where
     // take weighted sum of commitments via MSM
     let n = comms[0].comm.len();
     if !comms.iter().all(|c| c.comm.len() == n) {
-      return Err(SpartanError::InvalidInputLength {
+      return Err(VegaError::InvalidInputLength {
         reason: "fold_commitments: all inner commitment vectors must have the same length".into(),
       });
     }
@@ -795,15 +795,15 @@ where
   fn fold_blinds(
     blinds: &[Self::Blind],
     weights: &[<E as Engine>::Scalar],
-  ) -> Result<Self::Blind, SpartanError> {
+  ) -> Result<Self::Blind, VegaError> {
     if blinds.is_empty() || blinds.len() != weights.len() {
-      return Err(SpartanError::InvalidInputLength {
+      return Err(VegaError::InvalidInputLength {
         reason: "fold_blinds: blinds and weights must be non-empty and same length".into(),
       });
     }
     let n = blinds[0].blind.len();
     if !blinds.iter().all(|b| b.blind.len() == n) {
-      return Err(SpartanError::InvalidInputLength {
+      return Err(VegaError::InvalidInputLength {
         reason: "fold_blinds: all inner blind vectors must have the same length".into(),
       });
     }
@@ -824,9 +824,9 @@ where
     num_data_rows: usize,
     folded_blind: &Self::Blind,
     ck: &Self::CommitmentKey,
-  ) -> Result<Self::Commitment, SpartanError> {
+  ) -> Result<Self::Commitment, VegaError> {
     if comms.is_empty() || weights.is_empty() || comms.len() != weights.len() {
-      return Err(SpartanError::InvalidInputLength {
+      return Err(VegaError::InvalidInputLength {
         reason: "fold_commitments_partial: Commitments and weights must have the same length"
           .to_string(),
       });
@@ -834,7 +834,7 @@ where
 
     let total_rows = comms[0].comm.len();
     if num_data_rows > total_rows {
-      return Err(SpartanError::InvalidInputLength {
+      return Err(VegaError::InvalidInputLength {
         reason: format!(
           "fold_commitments_partial: num_data_rows ({}) exceeds total_rows ({})",
           num_data_rows, total_rows

--- a/src/provider/pcs/ipa.rs
+++ b/src/provider/pcs/ipa.rs
@@ -1,12 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
-// This file is part of the Spartan2 project.
+// This file is part of the vega-prover project.
 // See the LICENSE file in the project root for full license information.
-// Source repository: https://github.com/Microsoft/Spartan2
+// Source repository: https://github.com/Microsoft/vega-prover
 
 //! Inner Product Argument (IPA) implementation
 use crate::{
-  errors::SpartanError,
+  errors::VegaError,
   provider::traits::{DlogGroup, DlogGroupExt},
   traits::{
     Engine,
@@ -130,7 +130,7 @@ where
     U: &InnerProductInstance<E>,
     W: &InnerProductWitness<E>,
     transcript: &mut E::TE,
-  ) -> Result<Self, SpartanError> {
+  ) -> Result<Self, VegaError> {
     transcript.dom_sep(Self::protocol_name());
 
     // absorb the instance in the transcript
@@ -179,7 +179,7 @@ where
     n: usize,
     U: &InnerProductInstance<E>,
     transcript: &mut E::TE,
-  ) -> Result<(), SpartanError> {
+  ) -> Result<(), VegaError> {
     transcript.dom_sep(Self::protocol_name());
 
     // absorb the instance in the transcript
@@ -191,7 +191,7 @@ where
     let r = transcript.squeeze(b"r")?;
 
     if self.z_vec.len() != n || ck.len() < self.z_vec.len() {
-      return Err(SpartanError::InvalidInputLength {
+      return Err(VegaError::InvalidInputLength {
         reason: format!(
           "Inner product argument verify: Expected {} elements in z_vec, got {}",
           n,
@@ -204,7 +204,7 @@ where
       != E::GE::vartime_multiscalar_mul(&self.z_vec, &ck[0..self.z_vec.len()], true)?
         + *h * self.z_delta
     {
-      return Err(SpartanError::InvalidPCS {
+      return Err(VegaError::InvalidPCS {
         reason: "Inner product argument verify: First equation failed".to_string(),
       });
     }
@@ -212,7 +212,7 @@ where
     if U.comm_c * r + self.beta
       != E::GE::group(ck_c) * inner_product(&self.z_vec, &U.b_vec) + *h_c * self.z_beta
     {
-      return Err(SpartanError::InvalidPCS {
+      return Err(VegaError::InvalidPCS {
         reason: "Inner product argument verify: Second equation failed".to_string(),
       });
     }

--- a/src/provider/pcs/mod.rs
+++ b/src/provider/pcs/mod.rs
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
-// This file is part of the Spartan2 project.
+// This file is part of the vega-prover project.
 // See the LICENSE file in the project root for full license information.
-// Source repository: https://github.com/Microsoft/Spartan2
+// Source repository: https://github.com/Microsoft/vega-prover
 
 //! This module provides implementations of polynomial commitment schemes (PCS).
 

--- a/src/provider/pt256.rs
+++ b/src/provider/pt256.rs
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
-// This file is part of the Spartan2 project.
+// This file is part of the vega-prover project.
 // See the LICENSE file in the project root for full license information.
-// Source repository: https://github.com/Microsoft/Spartan2
+// Source repository: https://github.com/Microsoft/vega-prover
 
 //! This module implements the Spartan traits for P256 and T256 curves
 use crate::{

--- a/src/provider/traits.rs
+++ b/src/provider/traits.rs
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
-// This file is part of the Spartan2 project.
+// This file is part of the vega-prover project.
 // See the LICENSE file in the project root for full license information.
-// Source repository: https://github.com/Microsoft/Spartan2
+// Source repository: https://github.com/Microsoft/vega-prover
 
 //! Provides traits and extensions for groups, discrete logarithm operations, and homomorphic commitments.
 //!
@@ -22,7 +22,7 @@
 //! These traits and macros provide a consistent interface for elliptic curve operations
 //! and other algebraic structures used throughout the Spartan proof system.
 use crate::{
-  errors::SpartanError,
+  errors::VegaError,
   traits::{Group, transcript::TranscriptReprTrait},
 };
 use core::{
@@ -121,13 +121,13 @@ pub trait DlogGroupExt: DlogGroup {
     scalars: &[Self::Scalar],
     bases: &[Self::AffineGroupElement],
     use_parallelism_internally: bool,
-  ) -> Result<Self, SpartanError>;
+  ) -> Result<Self, VegaError>;
 
   /// A method to compute a batch of multiexponentations
   fn batch_vartime_multiscalar_mul(
     scalars: &[Vec<Self::Scalar>],
     bases: &[Self::AffineGroupElement],
-  ) -> Result<Vec<Self>, SpartanError> {
+  ) -> Result<Vec<Self>, VegaError> {
     scalars
       .par_iter()
       .map(|scalar| Self::vartime_multiscalar_mul(scalar, &bases[..scalar.len()], false))
@@ -139,13 +139,13 @@ pub trait DlogGroupExt: DlogGroup {
     scalars: &[T],
     bases: &[Self::AffineGroupElement],
     use_parallelism_internally: bool,
-  ) -> Result<Self, SpartanError>;
+  ) -> Result<Self, VegaError>;
 
   /// A method to compute a batch of multiexponentations with small scalars
   fn batch_vartime_multiscalar_mul_small<T: Integer + Into<u64> + Copy + Sync + ToPrimitive>(
     scalars: &[Vec<T>],
     bases: &[Self::AffineGroupElement],
-  ) -> Result<Vec<Self>, SpartanError> {
+  ) -> Result<Vec<Self>, VegaError> {
     scalars
       .par_iter()
       .map(|scalar| Self::vartime_multiscalar_mul_small(scalar, &bases[..scalar.len()], false))
@@ -158,7 +158,7 @@ pub trait DlogGroupExt: DlogGroup {
   fn vartime_multiscalar_mul_shared_weights(
     scalars: &[Self::Scalar],
     bases_rows: &[&[Self::AffineGroupElement]],
-  ) -> Result<Vec<Self>, SpartanError>;
+  ) -> Result<Vec<Self>, VegaError>;
 }
 
 /// Implements Spartan's traits except DlogGroupExt so that the MSM can be implemented differently
@@ -329,7 +329,7 @@ macro_rules! impl_traits {
         scalars: &[Self::Scalar],
         bases: &[Self::AffineGroupElement],
         use_parallelism_internally: bool,
-      ) -> Result<Self, $crate::errors::SpartanError> {
+      ) -> Result<Self, $crate::errors::VegaError> {
         msm(scalars, bases, use_parallelism_internally)
       }
 
@@ -337,14 +337,14 @@ macro_rules! impl_traits {
         scalars: &[T],
         bases: &[Self::AffineGroupElement],
         use_parallelism_internally: bool,
-      ) -> Result<Self, $crate::errors::SpartanError> {
+      ) -> Result<Self, $crate::errors::VegaError> {
         msm_small(scalars, bases, use_parallelism_internally)
       }
 
       fn vartime_multiscalar_mul_shared_weights(
         scalars: &[Self::Scalar],
         bases_rows: &[&[Self::AffineGroupElement]],
-      ) -> Result<Vec<Self>, $crate::errors::SpartanError> {
+      ) -> Result<Vec<Self>, $crate::errors::VegaError> {
         msm_shared_weights(scalars, bases_rows)
       }
     }

--- a/src/r1cs/folds.rs
+++ b/src/r1cs/folds.rs
@@ -1,14 +1,14 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
-// This file is part of the Spartan2 project.
+// This file is part of the vega-prover project.
 // See the LICENSE file in the project root for full license information.
-// Source repository: https://github.com/Microsoft/Spartan2
+// Source repository: https://github.com/Microsoft/vega-prover
 
 //! Extended folding utilities and cross-term commitment helpers for NIFS.
 #![allow(non_snake_case)]
 use crate::{
   Blind, Commitment, CommitmentKey, PCS,
-  errors::SpartanError,
+  errors::VegaError,
   r1cs::{R1CSInstance, R1CSShape, R1CSWitness, RelaxedR1CSInstance, RelaxedR1CSWitness},
   traits::{
     Engine,
@@ -33,15 +33,15 @@ impl<E: Engine> R1CSShape<E> {
     U2: &R1CSInstance<E>,
     W2: &R1CSWitness<E>,
     r_T: &Blind<E>,
-  ) -> Result<(Vec<E::Scalar>, Commitment<E>), SpartanError> {
+  ) -> Result<(Vec<E::Scalar>, Commitment<E>), VegaError> {
     // Form Z = (W1+W2, u1+1, X1+X2) without intermediate allocations.
     let n_w = W1.W.len();
     if W2.W.len() != n_w {
-      return Err(SpartanError::InvalidWitnessLength);
+      return Err(VegaError::InvalidWitnessLength);
     }
     let n_x = U1.X.len();
     if U2.X.len() != n_x {
-      return Err(SpartanError::InvalidInputLength {
+      return Err(VegaError::InvalidInputLength {
         reason: format!(
           "commit_T: U1.X.len() ({}) != U2.X.len() ({})",
           n_x,
@@ -115,9 +115,9 @@ where
     T: &[E::Scalar],
     r_T: &Blind<E>,
     r: &E::Scalar,
-  ) -> Result<RelaxedR1CSWitness<E>, SpartanError> {
+  ) -> Result<RelaxedR1CSWitness<E>, VegaError> {
     if self.W.len() != W2.W.len() || self.E.len() != T.len() {
-      return Err(SpartanError::InvalidWitnessLength);
+      return Err(VegaError::InvalidWitnessLength);
     }
 
     let W = self
@@ -234,9 +234,9 @@ where
   /// Fold this witness with another witness using barycentric weight `r_b`.
   ///
   /// The resulting witness corresponds to `(1 - r_b) * self + r_b * W2`.
-  pub fn fold(&self, w2: &R1CSWitness<E>, r_b: &E::Scalar) -> Result<Self, SpartanError> {
+  pub fn fold(&self, w2: &R1CSWitness<E>, r_b: &E::Scalar) -> Result<Self, VegaError> {
     if self.W.len() != w2.W.len() {
-      return Err(SpartanError::InvalidWitnessLength);
+      return Err(VegaError::InvalidWitnessLength);
     }
 
     // Combine the witness vectors.

--- a/src/r1cs/mod.rs
+++ b/src/r1cs/mod.rs
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
-// This file is part of the Spartan2 project.
+// This file is part of the vega-prover project.
 // See the LICENSE file in the project root for full license information.
-// Source repository: https://github.com/Microsoft/Spartan2
+// Source repository: https://github.com/Microsoft/vega-prover
 
 //! This module defines R1CS related types
 use crate::{
@@ -10,7 +10,7 @@ use crate::{
   big_num::DelayedReduction,
   big_num::montgomery::MontgomeryLimbs,
   digest::SimpleDigestible,
-  errors::SpartanError,
+  errors::VegaError,
   traits::{
     Engine,
     pcs::{FoldingEngineTrait, PCSEngineTrait},
@@ -219,10 +219,7 @@ pub struct RelaxedR1CSInstance<E: Engine> {
 
 impl<E: Engine> RelaxedR1CSWitness<E> {
   /// Commits to the witness using the supplied generators
-  pub fn commit(
-    &self,
-    ck: &CommitmentKey<E>,
-  ) -> Result<(Commitment<E>, Commitment<E>), SpartanError> {
+  pub fn commit(&self, ck: &CommitmentKey<E>) -> Result<(Commitment<E>, Commitment<E>), VegaError> {
     Ok((
       PCS::<E>::commit(ck, &self.W, &self.r_W, false)?,
       PCS::<E>::commit(ck, &self.E, &self.r_E, false)?,
@@ -314,11 +311,11 @@ fn is_sparse_matrix_valid<E: Engine>(
   num_rows: usize,
   num_cols: usize,
   M: &SparseMatrix<E::Scalar>,
-) -> Result<(), SpartanError> {
+) -> Result<(), VegaError> {
   // Check if the indices and indptr are valid for the given number of rows and columns
   M.iter().try_for_each(|(row, col, _val)| {
     if row >= num_rows || col >= num_cols {
-      Err(SpartanError::InvalidIndex)
+      Err(VegaError::InvalidIndex)
     } else {
       Ok(())
     }
@@ -334,7 +331,7 @@ impl<E: Engine> R1CSShape<E> {
     A: SparseMatrix<E::Scalar>,
     B: SparseMatrix<E::Scalar>,
     C: SparseMatrix<E::Scalar>,
-  ) -> Result<R1CSShape<E>, SpartanError> {
+  ) -> Result<R1CSShape<E>, VegaError> {
     let num_rows = num_cons;
     let num_cols = num_vars + 1 + num_io; // +1 for the constant term
 
@@ -360,7 +357,7 @@ impl<E: Engine> R1CSShape<E> {
     ck: &CommitmentKey<E>,
     U: &R1CSInstance<E>,
     W: &R1CSWitness<E>,
-  ) -> Result<(), SpartanError> {
+  ) -> Result<(), VegaError> {
     assert_eq!(W.W.len(), self.num_vars);
     assert_eq!(U.X.len(), self.num_io);
 
@@ -379,13 +376,13 @@ impl<E: Engine> R1CSShape<E> {
     let res_comm = U.comm_W == PCS::<E>::commit(ck, &W.W, &W.r_W, W.is_small)?;
 
     if !res_eq {
-      return Err(SpartanError::UnSat {
+      return Err(VegaError::UnSat {
         reason: "R1CS is unsatisfiable".to_string(),
       });
     }
 
     if !res_comm {
-      return Err(SpartanError::UnSat {
+      return Err(VegaError::UnSat {
         reason: "Invalid commitment".to_string(),
       });
     }
@@ -408,9 +405,9 @@ impl<E: Engine> R1CSShape<E> {
   pub fn multiply_vec(
     &self,
     z: &[E::Scalar],
-  ) -> Result<(Vec<E::Scalar>, Vec<E::Scalar>, Vec<E::Scalar>), SpartanError> {
+  ) -> Result<(Vec<E::Scalar>, Vec<E::Scalar>, Vec<E::Scalar>), VegaError> {
     if z.len() != self.num_io + 1 + self.num_vars {
-      return Err(SpartanError::InvalidWitnessLength);
+      return Err(VegaError::InvalidWitnessLength);
     }
 
     if rayon::current_num_threads() <= 1 {
@@ -432,7 +429,7 @@ impl<E: Engine> R1CSShape<E> {
     ck: &CommitmentKey<E>,
     U: &RelaxedR1CSInstance<E>,
     W: &RelaxedR1CSWitness<E>,
-  ) -> Result<(), SpartanError> {
+  ) -> Result<(), VegaError> {
     assert_eq!(W.W.len(), self.num_vars);
     assert_eq!(W.E.len(), self.num_cons);
     assert_eq!(U.X.len(), self.num_io);
@@ -456,13 +453,13 @@ impl<E: Engine> R1CSShape<E> {
     };
 
     if !res_eq {
-      return Err(SpartanError::UnSat {
+      return Err(VegaError::UnSat {
         reason: "Relaxed R1CS is unsatisfiable".to_string(),
       });
     }
 
     if !res_comm {
-      return Err(SpartanError::UnSat {
+      return Err(VegaError::UnSat {
         reason: "Invalid commitments".to_string(),
       });
     }
@@ -474,7 +471,7 @@ impl<E: Engine> R1CSShape<E> {
   pub fn sample_random_instance_witness(
     &self,
     ck: &CommitmentKey<E>,
-  ) -> Result<(RelaxedR1CSInstance<E>, RelaxedR1CSWitness<E>), SpartanError> {
+  ) -> Result<(RelaxedR1CSInstance<E>, RelaxedR1CSWitness<E>), VegaError> {
     // Bulk random generation: generate all random bytes at once via ChaCha CSPRNG,
     // then reduce each 64-byte chunk mod p via from_uniform (wide reduction).
     use crate::traits::PrimeFieldExt;
@@ -538,7 +535,7 @@ impl<E: Engine> R1CSWitness<E> {
     S: &R1CSShape<E>,
     W: &mut Vec<E::Scalar>,
     is_small: bool,
-  ) -> Result<(R1CSWitness<E>, Commitment<E>), SpartanError> {
+  ) -> Result<(R1CSWitness<E>, Commitment<E>), VegaError> {
     let r_W = PCS::<E>::blind(ck, W.len());
 
     // pad with zeros
@@ -562,7 +559,7 @@ impl<E: Engine> R1CSWitness<E> {
     W: Vec<E::Scalar>,
     r_W: Blind<E>,
     is_small: bool,
-  ) -> Result<R1CSWitness<E>, SpartanError> {
+  ) -> Result<R1CSWitness<E>, VegaError> {
     Ok(Self { W, r_W, is_small })
   }
 
@@ -570,13 +567,13 @@ impl<E: Engine> R1CSWitness<E> {
   pub fn fold_multiple(
     r_bs: &[E::Scalar],
     Ws: &[R1CSWitness<E>],
-  ) -> Result<R1CSWitness<E>, SpartanError>
+  ) -> Result<R1CSWitness<E>, VegaError>
   where
     E::PCS: FoldingEngineTrait<E>,
   {
     let n = Ws.len();
     if n == 0 {
-      return Err(SpartanError::InvalidInputLength {
+      return Err(VegaError::InvalidInputLength {
         reason: "fold_multiple: empty witness list".into(),
       });
     }
@@ -584,7 +581,7 @@ impl<E: Engine> R1CSWitness<E> {
     let w = weights_from_r::<E::Scalar>(r_bs, n);
 
     if w.len() != n {
-      return Err(SpartanError::InvalidInputLength {
+      return Err(VegaError::InvalidInputLength {
         reason: "fold_multiple: weights length mismatch".into(),
       });
     }
@@ -592,7 +589,7 @@ impl<E: Engine> R1CSWitness<E> {
     let dim = Ws[0].W.len();
 
     if !Ws.iter().all(|z| z.W.len() == dim) {
-      return Err(SpartanError::InvalidInputLength {
+      return Err(VegaError::InvalidInputLength {
         reason: "fold_multiple: all W vectors must have the same length".into(),
       });
     }
@@ -666,9 +663,9 @@ impl<E: Engine> R1CSInstance<E> {
     S: &R1CSShape<E>,
     comm_W: &Commitment<E>,
     X: &[E::Scalar],
-  ) -> Result<R1CSInstance<E>, SpartanError> {
+  ) -> Result<R1CSInstance<E>, VegaError> {
     if S.num_io != X.len() {
-      Err(SpartanError::InvalidInputLength {
+      Err(VegaError::InvalidInputLength {
         reason: format!(
           "R1CS instance: Expected {} elements in X, got {}",
           S.num_io,
@@ -687,7 +684,7 @@ impl<E: Engine> R1CSInstance<E> {
   pub fn new_unchecked(
     comm_W: Commitment<E>,
     X: Vec<E::Scalar>,
-  ) -> Result<R1CSInstance<E>, SpartanError> {
+  ) -> Result<R1CSInstance<E>, VegaError> {
     Ok(R1CSInstance { comm_W, X })
   }
 
@@ -695,7 +692,7 @@ impl<E: Engine> R1CSInstance<E> {
   pub fn fold_multiple(
     r_bs: &[E::Scalar],
     Us: &[R1CSInstance<E>],
-  ) -> Result<R1CSInstance<E>, SpartanError>
+  ) -> Result<R1CSInstance<E>, VegaError>
   where
     E::PCS: FoldingEngineTrait<E>,
   {
@@ -817,7 +814,7 @@ impl<E: Engine> SplitR1CSShape<E> {
     A: SparseMatrix<E::Scalar>,
     B: SparseMatrix<E::Scalar>,
     C: SparseMatrix<E::Scalar>,
-  ) -> Result<SplitR1CSShape<E>, SpartanError> {
+  ) -> Result<SplitR1CSShape<E>, VegaError> {
     let width = DEFAULT_COMMITMENT_WIDTH;
 
     let num_rows = num_cons;
@@ -1030,12 +1027,12 @@ impl<E: Engine> SplitR1CSShape<E> {
   ///
   pub fn commitment_key(
     shapes: &[&SplitR1CSShape<E>],
-  ) -> Result<(CommitmentKey<E>, VerifierKey<E>), SpartanError> {
+  ) -> Result<(CommitmentKey<E>, VerifierKey<E>), VegaError> {
     let max = shapes
       .iter()
       .map(|s| s.num_shared + s.num_precommitted + s.num_rest)
       .max()
-      .ok_or(SpartanError::InvalidInputLength {
+      .ok_or(VegaError::InvalidInputLength {
         reason: "commitment_key: unable to find max number of variables".to_string(),
       })?;
 
@@ -1075,7 +1072,7 @@ impl<E: Engine> SplitR1CSShape<E> {
   pub fn multiply_vec(
     &self,
     z: &[E::Scalar],
-  ) -> Result<(Vec<E::Scalar>, Vec<E::Scalar>, Vec<E::Scalar>), SpartanError> {
+  ) -> Result<(Vec<E::Scalar>, Vec<E::Scalar>, Vec<E::Scalar>), VegaError> {
     if z.len()
       != self.num_public
         + self.num_challenges
@@ -1084,7 +1081,7 @@ impl<E: Engine> SplitR1CSShape<E> {
         + self.num_precommitted
         + self.num_rest
     {
-      return Err(SpartanError::InvalidWitnessLength);
+      return Err(VegaError::InvalidWitnessLength);
     }
 
     self.ensure_precomputed();
@@ -1112,7 +1109,7 @@ impl<E: Engine> SplitR1CSShape<E> {
   pub fn multiply_vec_precommitted(
     &self,
     z_cached: &[E::Scalar],
-  ) -> Result<(Vec<E::Scalar>, Vec<E::Scalar>, Vec<E::Scalar>), SpartanError> {
+  ) -> Result<(Vec<E::Scalar>, Vec<E::Scalar>, Vec<E::Scalar>), VegaError> {
     let cached_len = self.num_shared + self.num_precommitted;
     assert_eq!(
       z_cached.len(),
@@ -1132,7 +1129,7 @@ impl<E: Engine> SplitR1CSShape<E> {
   pub fn multiply_vec_batched(
     &self,
     zs: &[Vec<E::Scalar>],
-  ) -> Result<Vec<(Vec<E::Scalar>, Vec<E::Scalar>, Vec<E::Scalar>)>, SpartanError> {
+  ) -> Result<Vec<(Vec<E::Scalar>, Vec<E::Scalar>, Vec<E::Scalar>)>, VegaError> {
     let expected_len = self.num_public
       + self.num_challenges
       + 1
@@ -1141,7 +1138,7 @@ impl<E: Engine> SplitR1CSShape<E> {
       + self.num_rest;
     for z in zs {
       if z.len() != expected_len {
-        return Err(SpartanError::InvalidWitnessLength);
+        return Err(VegaError::InvalidWitnessLength);
       }
     }
 
@@ -1176,7 +1173,7 @@ impl<E: Engine> SplitR1CSShape<E> {
     az: &mut Vec<E::Scalar>,
     bz: &mut Vec<E::Scalar>,
     cz: &mut Vec<E::Scalar>,
-  ) -> Result<(), SpartanError> {
+  ) -> Result<(), VegaError> {
     // Use filtered entries (built during precompute/setup)
     let col_min = self.num_shared + self.num_precommitted;
     let nr = self.num_cons_unpadded;
@@ -1438,9 +1435,9 @@ impl<E: Engine> SplitR1CSInstance<E> {
     comm_W_rest: Commitment<E>,
     public_values: Vec<E::Scalar>,
     challenges: Vec<E::Scalar>,
-  ) -> Result<SplitR1CSInstance<E>, SpartanError> {
+  ) -> Result<SplitR1CSInstance<E>, VegaError> {
     if public_values.len() != S.num_public {
-      return Err(SpartanError::InvalidInputLength {
+      return Err(VegaError::InvalidInputLength {
         reason: format!(
           "SplitR1CS instance: Expected {} public values, got {}",
           S.num_public,
@@ -1449,7 +1446,7 @@ impl<E: Engine> SplitR1CSInstance<E> {
       });
     }
     if challenges.len() != S.num_challenges {
-      return Err(SpartanError::InvalidInputLength {
+      return Err(VegaError::InvalidInputLength {
         reason: format!(
           "SplitR1CS instance: Expected {} challenges, got {}",
           S.num_challenges,
@@ -1460,12 +1457,12 @@ impl<E: Engine> SplitR1CSInstance<E> {
 
     // check if the commitments commit to the right number of variables
     if S.num_shared > 0 && comm_W_shared.is_none() {
-      return Err(SpartanError::InvalidCommitmentLength {
+      return Err(VegaError::InvalidCommitmentLength {
         reason: "comm_W_shared is missing".to_string(),
       });
     }
     if S.num_precommitted > 0 && comm_W_precommitted.is_none() {
-      return Err(SpartanError::InvalidCommitmentLength {
+      return Err(VegaError::InvalidCommitmentLength {
         reason: "comm_W_precommitted is missing".to_string(),
       });
     }
@@ -1487,17 +1484,13 @@ impl<E: Engine> SplitR1CSInstance<E> {
     })
   }
 
-  pub fn validate(
-    &self,
-    S: &SplitR1CSShape<E>,
-    transcript: &mut E::TE,
-  ) -> Result<(), SpartanError> {
+  pub fn validate(&self, S: &SplitR1CSShape<E>, transcript: &mut E::TE) -> Result<(), VegaError> {
     if S.num_shared > 0 {
       if let Some(comm) = &self.comm_W_shared {
         E::PCS::check_commitment(comm, S.num_shared, DEFAULT_COMMITMENT_WIDTH)?;
         transcript.absorb(b"comm_W_shared", comm);
       } else {
-        return Err(SpartanError::ProofVerifyError {
+        return Err(VegaError::ProofVerifyError {
           reason: "comm_W_shared is missing".to_string(),
         });
       }
@@ -1508,7 +1501,7 @@ impl<E: Engine> SplitR1CSInstance<E> {
         E::PCS::check_commitment(comm, S.num_precommitted, DEFAULT_COMMITMENT_WIDTH)?;
         transcript.absorb(b"comm_W_precommitted", comm);
       } else {
-        return Err(SpartanError::ProofVerifyError {
+        return Err(VegaError::ProofVerifyError {
           reason: "comm_W_precommitted is missing".to_string(),
         });
       }
@@ -1517,11 +1510,11 @@ impl<E: Engine> SplitR1CSInstance<E> {
     // obtain challenges from the transcript
     let challenges = (0..S.num_challenges)
       .map(|_| transcript.squeeze(b"challenge"))
-      .collect::<Result<Vec<E::Scalar>, SpartanError>>()?;
+      .collect::<Result<Vec<E::Scalar>, VegaError>>()?;
 
     // check that the challenges of the circuit matches the expected values
     if challenges != self.challenges {
-      return Err(SpartanError::ProofVerifyError {
+      return Err(VegaError::ProofVerifyError {
         reason: "Challenges do not match".to_string(),
       });
     }
@@ -1532,7 +1525,7 @@ impl<E: Engine> SplitR1CSInstance<E> {
     Ok(())
   }
 
-  pub fn to_regular_instance(&self) -> Result<R1CSInstance<E>, SpartanError> {
+  pub fn to_regular_instance(&self) -> Result<R1CSInstance<E>, VegaError> {
     let partial_comms = [
       self.comm_W_shared.clone(),
       self.comm_W_precommitted.clone(),
@@ -1561,10 +1554,10 @@ impl<E: Engine> SplitMultiRoundR1CSShape<E> {
     A: SparseMatrix<E::Scalar>,
     B: SparseMatrix<E::Scalar>,
     C: SparseMatrix<E::Scalar>,
-  ) -> Result<SplitMultiRoundR1CSShape<E>, SpartanError> {
+  ) -> Result<SplitMultiRoundR1CSShape<E>, VegaError> {
     let num_rounds = num_vars_per_round.len();
     if width == 0 || !width.is_power_of_two() {
-      return Err(SpartanError::InvalidInputLength {
+      return Err(VegaError::InvalidInputLength {
         reason: format!(
           "SplitMultiRoundR1CSShape: width must be a non-zero power of two, got {}",
           width
@@ -1572,7 +1565,7 @@ impl<E: Engine> SplitMultiRoundR1CSShape<E> {
       });
     }
     if num_challenges_per_round.len() != num_rounds {
-      return Err(SpartanError::InvalidInputLength {
+      return Err(VegaError::InvalidInputLength {
         reason: format!(
           "SplitMultiRoundR1CSShape: Expected {} challenges per round, got {}",
           num_rounds,
@@ -1691,12 +1684,12 @@ impl<E: Engine> SplitMultiRoundR1CSShape<E> {
   pub fn multiply_vec(
     &self,
     z: &[E::Scalar],
-  ) -> Result<(Vec<E::Scalar>, Vec<E::Scalar>, Vec<E::Scalar>), SpartanError> {
+  ) -> Result<(Vec<E::Scalar>, Vec<E::Scalar>, Vec<E::Scalar>), VegaError> {
     let total_vars: usize = self.num_vars_per_round.iter().sum();
     let total_challenges: usize = self.num_challenges_per_round.iter().sum();
 
     if z.len() != self.num_public + total_challenges + 1 + total_vars {
-      return Err(SpartanError::InvalidWitnessLength);
+      return Err(VegaError::InvalidWitnessLength);
     }
 
     let (az, (bz, cz)) = rayon::join(
@@ -1715,9 +1708,9 @@ impl<E: Engine> SplitMultiRoundR1CSInstance<E> {
     comm_w_per_round: Vec<Commitment<E>>,
     public_values: Vec<E::Scalar>,
     challenges_per_round: Vec<Vec<E::Scalar>>,
-  ) -> Result<SplitMultiRoundR1CSInstance<E>, SpartanError> {
+  ) -> Result<SplitMultiRoundR1CSInstance<E>, VegaError> {
     if public_values.len() != s.num_public {
-      return Err(SpartanError::InvalidInputLength {
+      return Err(VegaError::InvalidInputLength {
         reason: format!(
           "SplitMultiRoundR1CS instance: Expected {} public values, got {}",
           s.num_public,
@@ -1726,7 +1719,7 @@ impl<E: Engine> SplitMultiRoundR1CSInstance<E> {
       });
     }
     if challenges_per_round.len() != s.num_rounds {
-      return Err(SpartanError::InvalidInputLength {
+      return Err(VegaError::InvalidInputLength {
         reason: format!(
           "SplitMultiRoundR1CS instance: Expected {} rounds, got {}",
           s.num_rounds,
@@ -1735,7 +1728,7 @@ impl<E: Engine> SplitMultiRoundR1CSInstance<E> {
       });
     }
     if comm_w_per_round.len() != s.num_rounds {
-      return Err(SpartanError::InvalidInputLength {
+      return Err(VegaError::InvalidInputLength {
         reason: format!(
           "SplitMultiRoundR1CS instance: Expected {} rounds, got {}",
           s.num_rounds,
@@ -1747,7 +1740,7 @@ impl<E: Engine> SplitMultiRoundR1CSInstance<E> {
     // Validate challenges per round
     for (round, challenges) in challenges_per_round.iter().enumerate() {
       if challenges.len() != s.num_challenges_per_round[round] {
-        return Err(SpartanError::InvalidInputLength {
+        return Err(VegaError::InvalidInputLength {
           reason: format!(
             "SplitMultiRoundR1CS instance: Expected {} challenges in round {}, got {}",
             s.num_challenges_per_round[round],
@@ -1774,7 +1767,7 @@ impl<E: Engine> SplitMultiRoundR1CSInstance<E> {
     &self,
     s: &SplitMultiRoundR1CSShape<E>,
     transcript: &mut E::TE,
-  ) -> Result<(), SpartanError> {
+  ) -> Result<(), VegaError> {
     // Process each round, absorbing the previous round's commitment before deriving this round's challenges
     for round in 0..s.num_rounds {
       E::PCS::check_commitment(
@@ -1786,10 +1779,10 @@ impl<E: Engine> SplitMultiRoundR1CSInstance<E> {
 
       let derived_challenges = (0..s.num_challenges_per_round[round])
         .map(|_| transcript.squeeze(b"challenge"))
-        .collect::<Result<Vec<E::Scalar>, SpartanError>>()?;
+        .collect::<Result<Vec<E::Scalar>, VegaError>>()?;
 
       if self.challenges_per_round[round] != derived_challenges {
-        return Err(SpartanError::ProofVerifyError {
+        return Err(VegaError::ProofVerifyError {
           reason: format!("MultiRoundR1CSInstance:: Challenges do not match for round {round}"),
         });
       }
@@ -1798,7 +1791,7 @@ impl<E: Engine> SplitMultiRoundR1CSInstance<E> {
     Ok(())
   }
 
-  pub fn to_regular_instance(&self) -> Result<R1CSInstance<E>, SpartanError> {
+  pub fn to_regular_instance(&self) -> Result<R1CSInstance<E>, VegaError> {
     let partial_comms = self.comm_w_per_round.clone();
     let comm_w = PCS::<E>::combine_commitments(&partial_comms)?;
 

--- a/src/r1cs/sparse.rs
+++ b/src/r1cs/sparse.rs
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
-// This file is part of the Spartan2 project.
+// This file is part of the vega-prover project.
 // See the LICENSE file in the project root for full license information.
-// Source repository: https://github.com/Microsoft/Spartan2
+// Source repository: https://github.com/Microsoft/vega-prover
 
 //! # Sparse Matrices
 //!
@@ -13,7 +13,7 @@ use ff::PrimeField;
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 
-use crate::errors::SpartanError;
+use crate::errors::VegaError;
 
 /// Threshold below which we use sequential (non-rayon) iteration.
 const PARALLEL_THRESHOLD: usize = 4096;
@@ -472,10 +472,10 @@ impl<F: PrimeField> SparseMatrix<F> {
   /// Multiply by a dense vector; uses rayon/gpu.
   ///
   /// # Errors
-  /// Returns `SpartanError::InvalidInputLength` if the vector length doesn't match the matrix dimensions.
-  pub fn multiply_vec(&self, vector: &[F]) -> Result<Vec<F>, SpartanError> {
+  /// Returns `VegaError::InvalidInputLength` if the vector length doesn't match the matrix dimensions.
+  pub fn multiply_vec(&self, vector: &[F]) -> Result<Vec<F>, VegaError> {
     if self.cols != vector.len() {
-      return Err(SpartanError::InvalidInputLength {
+      return Err(VegaError::InvalidInputLength {
         reason: format!(
           "SparseMatrix multiply_vec: Expected {} elements in vector, got {}",
           self.cols,

--- a/src/spartan_relaxed.rs
+++ b/src/spartan_relaxed.rs
@@ -9,7 +9,7 @@
 #![allow(non_snake_case)]
 use crate::{
   CommitmentKey,
-  errors::SpartanError,
+  errors::VegaError,
   math::Math,
   polys::{eq::EqPolynomial, multilinear::MultilinearPolynomial},
   r1cs::{R1CSShape, RelaxedR1CSInstance, RelaxedR1CSWitness, SparseMatrix},
@@ -102,7 +102,7 @@ impl<E: Engine> RelaxedR1CSSpartanProof<E> {
     X: &[E::Scalar],
     W: &RelaxedR1CSWitness<E>,
     transcript: &mut E::TE,
-  ) -> Result<Self, SpartanError> {
+  ) -> Result<Self, VegaError> {
     transcript.absorb(b"u_relaxed", u);
     transcript.absorb(b"X_relaxed", &X);
 
@@ -123,7 +123,7 @@ impl<E: Engine> RelaxedR1CSSpartanProof<E> {
     // Outer sumcheck: sum_x eq(tau,x) * (Az(x)*Bz(x) - u*Cz(x) - E(x)) = 0
     let tau = (0..num_rounds_x)
       .map(|_| transcript.squeeze(b"t"))
-      .collect::<Result<Vec<_>, SpartanError>>()?;
+      .collect::<Result<Vec<_>, VegaError>>()?;
 
     // Third polynomial for cubic sumcheck: u*Cz + E
     let uCz_plus_E: Vec<E::Scalar> = Cz
@@ -221,7 +221,7 @@ impl<E: Engine> RelaxedR1CSSpartanProof<E> {
     vk_ee: &<E::PCS as PCSEngineTrait<E>>::VerifierKey,
     U: &RelaxedR1CSInstance<E>,
     transcript: &mut E::TE,
-  ) -> Result<(), SpartanError> {
+  ) -> Result<(), VegaError> {
     // Must match prover: absorb only (u, X) -- not the commitments.
     transcript.absorb(b"u_relaxed", &U.u);
     transcript.absorb(b"X_relaxed", &U.X.as_slice());
@@ -235,7 +235,7 @@ impl<E: Engine> RelaxedR1CSSpartanProof<E> {
     // Outer sumcheck
     let tau = (0..num_rounds_x)
       .map(|_| transcript.squeeze(b"t"))
-      .collect::<Result<EqPolynomial<_>, SpartanError>>()?;
+      .collect::<Result<EqPolynomial<_>, VegaError>>()?;
 
     let (claim_outer_final, r_x) =
       self
@@ -246,7 +246,7 @@ impl<E: Engine> RelaxedR1CSSpartanProof<E> {
     let taus_bound_rx = tau.evaluate(&r_x);
     let claim_outer_expected = taus_bound_rx * (claim_Az * claim_Bz - claim_uCzE);
     if claim_outer_final != claim_outer_expected {
-      return Err(SpartanError::InvalidSumcheckProof);
+      return Err(VegaError::InvalidSumcheckProof);
     }
 
     transcript.absorb(
@@ -296,7 +296,7 @@ impl<E: Engine> RelaxedR1CSSpartanProof<E> {
 
     let claim_inner_expected = eval_ABC * eval_Z;
     if claim_inner_final != claim_inner_expected {
-      return Err(SpartanError::InvalidSumcheckProof);
+      return Err(VegaError::InvalidSumcheckProof);
     }
 
     // Absorb direct opening vectors into transcript (must match prover)

--- a/src/sumcheck.rs
+++ b/src/sumcheck.rs
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
-// This file is part of the Spartan2 project.
+// This file is part of the vega-prover project.
 // See the LICENSE file in the project root for full license information.
-// Source repository: https://github.com/Microsoft/Spartan2
+// Source repository: https://github.com/Microsoft/vega-prover
 
 //! This module implements the sum-check protocol used in Spartan.
 //!
@@ -13,11 +13,11 @@
 use crate::{
   CommitmentKey,
   bellpepper::{
-    r1cs::{MultiRoundSpartanWitness, MultiRoundState},
+    r1cs::{MultiRoundState, MultiRoundVegaWitness},
     solver::SatisfyingAssignment,
   },
   big_num::DelayedReduction,
-  errors::SpartanError,
+  errors::VegaError,
   polys::{
     multilinear::MultilinearPolynomial,
     univariate::{CompressedUniPoly, UniPoly},
@@ -25,7 +25,7 @@ use crate::{
   r1cs::SplitMultiRoundR1CSShape,
   start_span,
   traits::{Engine, transcript::TranscriptEngineTrait},
-  zk::{NeutronNovaVerifierCircuit, SpartanVerifierCircuit},
+  zk::{VegaMcVerifierCircuit, VegaVerifierCircuit},
 };
 use ff::Field;
 use rayon::prelude::*;
@@ -70,14 +70,14 @@ impl<E: Engine> SumcheckProof<E> {
     num_rounds: usize,
     degree_bound: usize,
     transcript: &mut E::TE,
-  ) -> Result<(E::Scalar, Vec<E::Scalar>), SpartanError> {
+  ) -> Result<(E::Scalar, Vec<E::Scalar>), VegaError> {
     let (_verify_span, verify_t) = start_span!("sumcheck_verify");
     let mut e = claim;
     let mut r: Vec<E::Scalar> = Vec::new();
 
     // verify that there is a univariate polynomial for each round
     if self.compressed_polys.len() != num_rounds {
-      return Err(SpartanError::InvalidSumcheckProof);
+      return Err(VegaError::InvalidSumcheckProof);
     }
 
     for i in 0..self.compressed_polys.len() {
@@ -86,7 +86,7 @@ impl<E: Engine> SumcheckProof<E> {
 
       // verify degree bound
       if poly.degree() != degree_bound {
-        return Err(SpartanError::InvalidSumcheckProof);
+        return Err(VegaError::InvalidSumcheckProof);
       }
 
       // we do not need to check if poly(0) + poly(1) = e, as
@@ -193,7 +193,7 @@ impl<E: Engine> SumcheckProof<E> {
     poly_A: &mut MultilinearPolynomial<E::Scalar>,
     poly_B: &mut MultilinearPolynomial<E::Scalar>,
     transcript: &mut E::TE,
-  ) -> Result<(Self, Vec<E::Scalar>, Vec<E::Scalar>), SpartanError> {
+  ) -> Result<(Self, Vec<E::Scalar>, Vec<E::Scalar>), VegaError> {
     let mut r: Vec<E::Scalar> = Vec::new();
     let mut polys: Vec<CompressedUniPoly<E::Scalar>> = Vec::new();
     let mut claim_per_round = *claim;
@@ -506,7 +506,7 @@ impl<E: Engine> SumcheckProof<E> {
     poly_B: &mut MultilinearPolynomial<E::Scalar>,
     poly_C: &mut MultilinearPolynomial<E::Scalar>,
     transcript: &mut E::TE,
-  ) -> Result<(Self, Vec<E::Scalar>, Vec<E::Scalar>), SpartanError> {
+  ) -> Result<(Self, Vec<E::Scalar>, Vec<E::Scalar>), VegaError> {
     let mut r: Vec<E::Scalar> = Vec::new();
     let mut polys: Vec<CompressedUniPoly<E::Scalar>> = Vec::new();
     let mut claim_per_round = *claim;
@@ -578,12 +578,12 @@ impl<E: Engine> SumcheckProof<E> {
     poly_Az: &mut MultilinearPolynomial<E::Scalar>,
     poly_Bz: &mut MultilinearPolynomial<E::Scalar>,
     poly_Cz: &mut MultilinearPolynomial<E::Scalar>,
-    verifier_circuit: &mut SpartanVerifierCircuit<E>,
+    verifier_circuit: &mut VegaVerifierCircuit<E>,
     state: &mut MultiRoundState<E>,
     vc_shape: &SplitMultiRoundR1CSShape<E>,
     vc_ck: &CommitmentKey<E>,
     transcript: &mut E::TE,
-  ) -> Result<Vec<E::Scalar>, SpartanError> {
+  ) -> Result<Vec<E::Scalar>, VegaError> {
     let mut r_x: Vec<E::Scalar> = Vec::with_capacity(num_rounds);
     let mut claim_outer_round = E::Scalar::ZERO;
     let mut eq_instance = eq_sumcheck::EqSumCheckInstance::<E>::new(taus.to_vec());
@@ -648,14 +648,14 @@ impl<E: Engine> SumcheckProof<E> {
     num_rounds: usize,
     poly_ABC: &mut MultilinearPolynomial<E::Scalar>,
     poly_z: &mut MultilinearPolynomial<E::Scalar>,
-    verifier_circuit: &mut SpartanVerifierCircuit<E>,
+    verifier_circuit: &mut VegaVerifierCircuit<E>,
     state: &mut MultiRoundState<E>,
     vc_shape: &SplitMultiRoundR1CSShape<E>,
     vc_ck: &CommitmentKey<E>,
     transcript: &mut E::TE,
     start_round: usize,
     inner_poly_offset: usize,
-  ) -> Result<(Vec<E::Scalar>, Vec<E::Scalar>), SpartanError> {
+  ) -> Result<(Vec<E::Scalar>, Vec<E::Scalar>), VegaError> {
     let mut r_y: Vec<E::Scalar> = Vec::with_capacity(num_rounds);
     let mut claim_current_round = *claim;
 
@@ -706,13 +706,13 @@ impl<E: Engine> SumcheckProof<E> {
     poly_A_1: &mut MultilinearPolynomial<E::Scalar>,
     poly_B_0: &mut MultilinearPolynomial<E::Scalar>,
     poly_B_1: &mut MultilinearPolynomial<E::Scalar>,
-    verifier_circuit: &mut NeutronNovaVerifierCircuit<E>,
+    verifier_circuit: &mut VegaMcVerifierCircuit<E>,
     state: &mut MultiRoundState<E>,
     vc_shape: &SplitMultiRoundR1CSShape<E>,
     vc_ck: &CommitmentKey<E>,
     transcript: &mut E::TE,
     start_round: usize,
-  ) -> Result<(Vec<E::Scalar>, Vec<E::Scalar>), SpartanError> {
+  ) -> Result<(Vec<E::Scalar>, Vec<E::Scalar>), VegaError> {
     let mut r_y: Vec<E::Scalar> = Vec::with_capacity(num_rounds);
     // Maintain separate claims for step and core branches
     let mut claim_step_round = claims[0];
@@ -793,13 +793,13 @@ impl<E: Engine> SumcheckProof<E> {
     poly_B_core: &mut MultilinearPolynomial<E::Scalar>,
     poly_C_step: &mut MultilinearPolynomial<E::Scalar>,
     poly_C_core: &mut MultilinearPolynomial<E::Scalar>,
-    verifier_circuit: &mut NeutronNovaVerifierCircuit<E>,
+    verifier_circuit: &mut VegaMcVerifierCircuit<E>,
     state: &mut MultiRoundState<E>,
     vc_shape: &SplitMultiRoundR1CSShape<E>,
     vc_ck: &CommitmentKey<E>,
     transcript: &mut E::TE,
     start_round: usize,
-  ) -> Result<Vec<E::Scalar>, SpartanError> {
+  ) -> Result<Vec<E::Scalar>, VegaError> {
     let mut base_tau = E::Scalar::ONE;
     let mut len_pow_tau = pow_tau_left.Z.len() * pow_tau_right.Z.len();
 

--- a/src/traits/circuit.rs
+++ b/src/traits/circuit.rs
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
-// This file is part of the Spartan2 project.
+// This file is part of the vega-prover project.
 // See the LICENSE file in the project root for full license information.
-// Source repository: https://github.com/Microsoft/Spartan2
+// Source repository: https://github.com/Microsoft/vega-prover
 
 //! This module defines traits that a circuit provider must implement to be used with Spartan.
 use crate::traits::Engine;
@@ -16,7 +16,7 @@ use bellpepper_core::{ConstraintSystem, SynthesisError, num::AllocatedNum};
 /// (3) the prover commits to aux variables
 /// (4) The circuit checks a set of constraints over witness = (shared, precommitted, aux)
 /// The public IO includes the challenge and other things made public by the circuit
-pub trait SpartanCircuit<E: Engine>: Send + Sync + Clone {
+pub trait VegaCircuit<E: Engine>: Send + Sync + Clone {
   /// Returns the public values of the circuit, which is the list of values that will be made public
   /// The circuit must make public these values followed by the challenges generated via the transcript
   fn public_values(&self) -> Result<Vec<E::Scalar>, SynthesisError>;
@@ -53,7 +53,7 @@ pub trait SpartanCircuit<E: Engine>: Send + Sync + Clone {
 }
 
 /// A helper trait for defining a multi-round randomized circuit that Spartan proves.
-/// Unlike the standard SpartanCircuit, this trait allows the circuit to be processed in multiple rounds,
+/// Unlike the standard VegaCircuit, this trait allows the circuit to be processed in multiple rounds,
 /// where each round can allocate different constraints and witness variables based on the round index.
 /// The public IO includes the challenges and other things made public by the circuit across all rounds.
 pub trait MultiRoundCircuit<E: Engine>: Send + Sync + Clone {

--- a/src/traits/mod.rs
+++ b/src/traits/mod.rs
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
-// This file is part of the Spartan2 project.
+// This file is part of the vega-prover project.
 // See the LICENSE file in the project root for full license information.
-// Source repository: https://github.com/Microsoft/Spartan2
+// Source repository: https://github.com/Microsoft/vega-prover
 
 //! This module defines various traits required by the users of the library to implement.
 use core::fmt::Debug;

--- a/src/traits/pcs.rs
+++ b/src/traits/pcs.rs
@@ -1,13 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
-// This file is part of the Spartan2 project.
+// This file is part of the vega-prover project.
 // See the LICENSE file in the project root for full license information.
-// Source repository: https://github.com/Microsoft/Spartan2
+// Source repository: https://github.com/Microsoft/vega-prover
 
 //! This module defines a collection of traits that define the behavior of a commitment engine
 //! We require the commitment engine to provide a commitment to vectors with a single group element
 use crate::{
-  errors::SpartanError,
+  errors::VegaError,
   traits::{Engine, TranscriptReprTrait},
 };
 use core::fmt::Debug;
@@ -66,7 +66,7 @@ pub trait PCSEngineTrait<E: Engine>: Clone + Send + Sync {
     v: &[E::Scalar],
     r: &Self::Blind,
     is_small: bool,
-  ) -> Result<Self::Commitment, SpartanError>;
+  ) -> Result<Self::Commitment, VegaError>;
 
   /// Commits to an all-zero vector of size `n` with the given blind.
   /// Default: creates a zero vector and calls `commit`. Implementations may override
@@ -75,13 +75,13 @@ pub trait PCSEngineTrait<E: Engine>: Clone + Send + Sync {
     ck: &Self::CommitmentKey,
     n: usize,
     r: &Self::Blind,
-  ) -> Result<Self::Commitment, SpartanError> {
+  ) -> Result<Self::Commitment, VegaError> {
     let zeros = vec![E::Scalar::ZERO; n];
     Self::commit(ck, &zeros, r, true)
   }
 
   /// Checks if the provided commitment commits to a vector of the specified length
-  fn check_commitment(comm: &Self::Commitment, n: usize, width: usize) -> Result<(), SpartanError>;
+  fn check_commitment(comm: &Self::Commitment, n: usize, width: usize) -> Result<(), VegaError>;
 
   /// Rerandomizes the provided commitment using the provided blind
   fn rerandomize_commitment(
@@ -89,7 +89,7 @@ pub trait PCSEngineTrait<E: Engine>: Clone + Send + Sync {
     comm: &Self::Commitment,
     r_old: &Self::Blind,
     r_new: &Self::Blind,
-  ) -> Result<Self::Commitment, SpartanError>;
+  ) -> Result<Self::Commitment, VegaError>;
 
   /// Combines the provided commitments (each committing to a multilinear polynomial) into a single commitment.
   ///
@@ -102,17 +102,17 @@ pub trait PCSEngineTrait<E: Engine>: Clone + Send + Sync {
   ///
   /// # Returns
   /// - A single combined commitment if the operation is successful.
-  /// - An error of type `SpartanError` if the combination fails due to invalid inputs or mismatched constraints.
+  /// - An error of type `VegaError` if the combination fails due to invalid inputs or mismatched constraints.
   ///
   /// # Usage
   /// This method is used to finalize the commitment after multiple commitments have been made.
   /// Ensure that the commitments are provided in the correct order and meet all constraints.
-  fn combine_commitments(comms: &[Self::Commitment]) -> Result<Self::Commitment, SpartanError>;
+  fn combine_commitments(comms: &[Self::Commitment]) -> Result<Self::Commitment, VegaError>;
 
   /// Combines the provided blinds into a single blind.
   /// The order of the blinds must match the order of the commitments used to generate them
   /// Returns an error if the combination fails
-  fn combine_blinds(blinds: &[Self::Blind]) -> Result<Self::Blind, SpartanError>;
+  fn combine_blinds(blinds: &[Self::Blind]) -> Result<Self::Blind, VegaError>;
 
   /// A method to prove the evaluation of a multilinear polynomial
   fn prove(
@@ -125,7 +125,7 @@ pub trait PCSEngineTrait<E: Engine>: Clone + Send + Sync {
     point: &[E::Scalar],
     comm_eval: &Self::Commitment,
     blind_eval: &Self::Blind,
-  ) -> Result<Self::EvaluationArgument, SpartanError>;
+  ) -> Result<Self::EvaluationArgument, VegaError>;
 
   /// A method to verify the purported evaluation of a multilinear polynomials
   fn verify(
@@ -136,7 +136,7 @@ pub trait PCSEngineTrait<E: Engine>: Clone + Send + Sync {
     point: &[E::Scalar],
     comm_eval: &Self::Commitment,
     arg: &Self::EvaluationArgument,
-  ) -> Result<(), SpartanError>;
+  ) -> Result<(), VegaError>;
 
   /// Compute raw (unblinded) commitment. Returns per-row group elements.
   /// Default: not supported (panics). Override for schemes that support this.
@@ -144,8 +144,8 @@ pub trait PCSEngineTrait<E: Engine>: Clone + Send + Sync {
     _ck: &Self::CommitmentKey,
     _v: &[E::Scalar],
     _is_small: bool,
-  ) -> Result<Vec<E::GE>, SpartanError> {
-    Err(SpartanError::InternalError {
+  ) -> Result<Vec<E::GE>, VegaError> {
+    Err(VegaError::InternalError {
       reason: "commit_without_blind not supported for this PCS".to_string(),
     })
   }
@@ -158,8 +158,8 @@ pub trait PCSEngineTrait<E: Engine>: Clone + Send + Sync {
     _raw: &[E::GE],
     _delta: &[E::Scalar],
     _blind: &Self::Blind,
-  ) -> Result<Self::Commitment, SpartanError> {
-    Err(SpartanError::InternalError {
+  ) -> Result<Self::Commitment, VegaError> {
+    Err(VegaError::InternalError {
       reason: "commit_incremental not supported for this PCS".to_string(),
     })
   }
@@ -176,8 +176,8 @@ pub trait PCSEngineTrait<E: Engine>: Clone + Send + Sync {
     _poly: &[E::Scalar],
     _blind: &Self::Blind,
     _point: &[E::Scalar],
-  ) -> Result<(Vec<E::Scalar>, E::Scalar), SpartanError> {
-    Err(SpartanError::InternalError {
+  ) -> Result<(Vec<E::Scalar>, E::Scalar), VegaError> {
+    Err(VegaError::InternalError {
       reason: "prove_direct not supported for this PCS".to_string(),
     })
   }
@@ -192,8 +192,8 @@ pub trait PCSEngineTrait<E: Engine>: Clone + Send + Sync {
     _v: &[E::Scalar],
     _combined_blind: &E::Scalar,
     _point: &[E::Scalar],
-  ) -> Result<E::Scalar, SpartanError> {
-    Err(SpartanError::InternalError {
+  ) -> Result<E::Scalar, VegaError> {
+    Err(VegaError::InternalError {
       reason: "verify_direct not supported for this PCS".to_string(),
     })
   }
@@ -207,14 +207,11 @@ pub trait FoldingEngineTrait<E: Engine>: PCSEngineTrait<E> {
   fn fold_commitments(
     comms: &[Self::Commitment],
     weights: &[E::Scalar],
-  ) -> Result<Self::Commitment, SpartanError>;
+  ) -> Result<Self::Commitment, VegaError>;
 
   /// A method to fold the provided blinds into a single blind using the provided weights
   /// The weights should be the same length as the number of blinds
-  fn fold_blinds(
-    blinds: &[Self::Blind],
-    weights: &[E::Scalar],
-  ) -> Result<Self::Blind, SpartanError>;
+  fn fold_blinds(blinds: &[Self::Blind], weights: &[E::Scalar]) -> Result<Self::Blind, VegaError>;
 
   /// Fold commitments, but for rows beyond `num_data_rows`, compute from
   /// folded blind + h instead of full MSM. This is an optimization for
@@ -226,7 +223,7 @@ pub trait FoldingEngineTrait<E: Engine>: PCSEngineTrait<E> {
     _num_data_rows: usize,
     _folded_blind: &Self::Blind,
     _ck: &Self::CommitmentKey,
-  ) -> Result<Self::Commitment, SpartanError> {
+  ) -> Result<Self::Commitment, VegaError> {
     Self::fold_commitments(comms, weights)
   }
 }

--- a/src/traits/snark.rs
+++ b/src/traits/snark.rs
@@ -1,13 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
-// This file is part of the Spartan2 project.
+// This file is part of the vega-prover project.
 // See the LICENSE file in the project root for full license information.
-// Source repository: https://github.com/Microsoft/Spartan2
+// Source repository: https://github.com/Microsoft/vega-prover
 
 //! This module defines a collection of traits that define the behavior of a zkSNARK for RelaxedR1CS
 use crate::{
-  errors::SpartanError,
-  traits::{Engine, Group, TranscriptReprTrait, circuit::SpartanCircuit},
+  errors::VegaError,
+  traits::{Engine, Group, TranscriptReprTrait, circuit::VegaCircuit},
 };
 use serde::{Deserialize, Serialize};
 
@@ -25,42 +25,42 @@ pub trait R1CSSNARKTrait<E: Engine>:
   type PrepSNARK: Clone + Send + Sync + Serialize + for<'de> Deserialize<'de>;
 
   /// Produces the keys for the prover and the verifier
-  fn setup<C: SpartanCircuit<E>>(
+  fn setup<C: VegaCircuit<E>>(
     circuit: C,
-  ) -> Result<(Self::ProverKey, Self::VerifierKey), SpartanError>;
+  ) -> Result<(Self::ProverKey, Self::VerifierKey), VegaError>;
 
   /// Prepares the SNARK for proving, given a prover key and a circuit
-  fn prep_prove<C: SpartanCircuit<E>>(
+  fn prep_prove<C: VegaCircuit<E>>(
     pk: &Self::ProverKey,
     circuit: C,
     is_small: bool, // do witness elements fit in machine words?
-  ) -> Result<Self::PrepSNARK, SpartanError>;
+  ) -> Result<Self::PrepSNARK, VegaError>;
 
   /// Produces witness and instance for a given circuit, and proves it.
   /// Takes ownership of the prep state and returns it alongside the proof
   /// so it can be rerandomized and reused for subsequent proofs.
-  fn prove<C: SpartanCircuit<E>>(
+  fn prove<C: VegaCircuit<E>>(
     pk: &Self::ProverKey,
     circuit: C,
     prep_snark: Self::PrepSNARK,
     is_small: bool, // do witness elements fit in machine words?
-  ) -> Result<(Self, Self::PrepSNARK), SpartanError>;
+  ) -> Result<(Self, Self::PrepSNARK), VegaError>;
 
   /// Verifies a SNARK for a relaxed R1CS and returns the public IO
-  fn verify(&self, vk: &Self::VerifierKey) -> Result<Vec<E::Scalar>, SpartanError>;
+  fn verify(&self, vk: &Self::VerifierKey) -> Result<Vec<E::Scalar>, VegaError>;
 }
 
 /// A type representing the digest of a verifier's key
-pub type SpartanDigest = [u8; 32];
+pub type VegaDigest = [u8; 32];
 
 /// A helper trait that defines the behavior of a verifier key of `zkSNARK`
 pub trait DigestHelperTrait<E: Engine> {
   /// Returns the digest of the verifier's key
-  fn digest(&self) -> Result<SpartanDigest, SpartanError>;
+  fn digest(&self) -> Result<VegaDigest, VegaError>;
 }
 
-// implement TranscriptReprTrait for the SpartanDigest
-impl<G: Group> TranscriptReprTrait<G> for SpartanDigest {
+// implement TranscriptReprTrait for the VegaDigest
+impl<G: Group> TranscriptReprTrait<G> for VegaDigest {
   fn to_transcript_bytes(&self) -> Vec<u8> {
     self.to_vec()
   }

--- a/src/traits/transcript.rs
+++ b/src/traits/transcript.rs
@@ -1,13 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
-// This file is part of the Spartan2 project.
+// This file is part of the vega-prover project.
 // See the LICENSE file in the project root for full license information.
-// Source repository: https://github.com/Microsoft/Spartan2
+// Source repository: https://github.com/Microsoft/vega-prover
 
-//! This module provides the trait definitions for transcript functionality in the Spartan2 library.
+//! This module provides the trait definitions for transcript functionality in the vega-prover library.
 //! Transcripts are used for Fiat-Shamir transformations to make interactive proof systems non-interactive.
 use crate::{
-  errors::SpartanError,
+  errors::VegaError,
   traits::{Engine, Group},
 };
 
@@ -23,7 +23,7 @@ pub trait TranscriptEngineTrait<E: Engine>: Send + Sync {
   fn new(label: &'static [u8]) -> Self;
 
   /// returns a scalar element of the group as a challenge
-  fn squeeze(&mut self, label: &'static [u8]) -> Result<E::Scalar, SpartanError>;
+  fn squeeze(&mut self, label: &'static [u8]) -> Result<E::Scalar, VegaError>;
 
   /// absorbs any type that implements `TranscriptReprTrait` under a label
   fn absorb<T: TranscriptReprTrait<E::GE>>(&mut self, label: &'static [u8], o: &T);

--- a/src/vega_mc_zkp.rs
+++ b/src/vega_mc_zkp.rs
@@ -1,22 +1,15 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
-// This file is part of the Spartan2 project.
+// This file is part of the vega-prover project.
 // See the LICENSE file in the project root for full license information.
-// Source repository: https://github.com/Microsoft/Spartan2
+// Source repository: https://github.com/Microsoft/vega-prover
 
-//! This module implements NeutronNova's folding scheme for folding together a batch of R1CS instances
-//! This implementation focuses on a non-recursive version of NeutronNova and targets the case where the batch size is moderately large.
-//! Since we are in the non-recursive setting, we simply fold a batch of instances into one (all at once, via multi-folding)
-//! and then use Spartan to prove that folded instance.
-//! The proof system implemented here provides zero-knowledge via Nova's folding scheme.
+//! Multi-circuit (MC) prover using NeutronNova folding (https://eprint.iacr.org/2024/1606), proved with the single-circuit prover.
 use crate::start_span;
 use crate::{
   Commitment, CommitmentKey, DEFAULT_COMMITMENT_WIDTH, VerifierKey,
   bellpepper::{
-    r1cs::{
-      MultiRoundSpartanShape, MultiRoundSpartanWitness, PrecommittedState, SpartanShape,
-      SpartanWitness,
-    },
+    r1cs::{MultiRoundVegaShape, MultiRoundVegaWitness, PrecommittedState, VegaShape, VegaWitness},
     shape_cs::ShapeCS,
     solver::SatisfyingAssignment,
   },
@@ -26,7 +19,7 @@ use crate::{
     small_value::{SmallAccumulator, to_small_vec_or_zero},
   },
   digest::DigestComputer,
-  errors::SpartanError,
+  errors::VegaError,
   math::Math,
   nifs::NovaNIFS,
   polys::{
@@ -42,12 +35,12 @@ use crate::{
   sumcheck::SumcheckProof,
   traits::{
     Engine,
-    circuit::SpartanCircuit,
+    circuit::VegaCircuit,
     pcs::{FoldingEngineTrait, PCSEngineTrait},
-    snark::{DigestHelperTrait, SpartanDigest},
+    snark::{DigestHelperTrait, VegaDigest},
     transcript::TranscriptEngineTrait,
   },
-  zk::NeutronNovaVerifierCircuit,
+  zk::VegaMcVerifierCircuit,
 };
 use ff::Field;
 use once_cell::sync::OnceCell;
@@ -69,7 +62,7 @@ fn compute_tensor_decomp(n: usize) -> (usize, usize, usize) {
 /// A type that holds the NeutronNova NIFS (Non-Interactive Folding Scheme)
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(bound = "")]
-pub struct NeutronNovaNIFS<E: Engine> {
+pub struct VegaMcNIFS<E: Engine> {
   polys: Vec<UniPoly<E::Scalar>>,
 }
 
@@ -86,7 +79,7 @@ fn suffix_weight_full<F: Field>(t: usize, ell_b: usize, pair_idx: usize, rhos: &
   w
 }
 
-impl<E: Engine> NeutronNovaNIFS<E>
+impl<E: Engine> VegaMcNIFS<E>
 where
   E::PCS: FoldingEngineTrait<E>,
 {
@@ -516,8 +509,8 @@ where
     cached_matvec: Option<Vec<(Vec<E::Scalar>, Vec<E::Scalar>, Vec<E::Scalar>)>>,
     cached_i64: Option<Vec<(Vec<i64>, Vec<i64>, Vec<i64>)>>,
     large_positions: &[usize],
-    vc: &mut NeutronNovaVerifierCircuit<E>,
-    vc_state: &mut <SatisfyingAssignment<E> as MultiRoundSpartanWitness<E>>::MultiRoundState,
+    vc: &mut VegaMcVerifierCircuit<E>,
+    vc_state: &mut <SatisfyingAssignment<E> as MultiRoundVegaWitness<E>>::MultiRoundState,
     vc_shape: &SplitMultiRoundR1CSShape<E>,
     vc_ck: &CommitmentKey<E>,
     transcript: &mut E::TE,
@@ -530,7 +523,7 @@ where
       R1CSWitness<E>,  // final folded witness
       R1CSInstance<E>, // final folded instance
     ),
-    SpartanError,
+    VegaError,
   > {
     // Determine padding and NIFS rounds
     let n = Us.len();
@@ -708,7 +701,7 @@ where
         let c = $e0 * acc_eq;
         let a = $quad_coeff * acc_eq;
         let rho_t_inv: Option<E::Scalar> = rho_t.invert().into();
-        let a_b_c = (T_cur - c * one_minus_rho) * rho_t_inv.ok_or(SpartanError::DivisionByZero)?;
+        let a_b_c = (T_cur - c * one_minus_rho) * rho_t_inv.ok_or(VegaError::DivisionByZero)?;
         let b = a_b_c - a - c;
         let new_a = a * two_rho_minus_one;
         let new_b = b * two_rho_minus_one + a * one_minus_rho;
@@ -1205,7 +1198,7 @@ where
     }
     // T_out = poly_last(r_last) / eq(r_b, rho)
     let acc_eq_inv: Option<E::Scalar> = acc_eq.invert().into();
-    let T_out = T_cur * acc_eq_inv.ok_or(SpartanError::DivisionByZero)?;
+    let T_out = T_cur * acc_eq_inv.ok_or(VegaError::DivisionByZero)?;
     vc.t_out_step = T_out;
     vc.eq_rho_at_rb = acc_eq;
     let _ =
@@ -1276,11 +1269,11 @@ where
 /// A type that represents the prover's key
 #[derive(Serialize, Deserialize)]
 #[serde(bound = "")]
-pub struct NeutronNovaProverKey<E: Engine> {
+pub struct VegaMcProverKey<E: Engine> {
   ck: CommitmentKey<E>,
   S_step: SplitR1CSShape<E>,
   S_core: SplitR1CSShape<E>,
-  vk_digest: SpartanDigest, // digest of the verifier's key
+  vk_digest: VegaDigest, // digest of the verifier's key
   vc_shape: SplitMultiRoundR1CSShape<E>,
   vc_shape_regular: R1CSShape<E>,
   vc_ck: CommitmentKey<E>,
@@ -1289,7 +1282,7 @@ pub struct NeutronNovaProverKey<E: Engine> {
 /// A type that represents the verifier's key
 #[derive(Serialize, Deserialize)]
 #[serde(bound = "")]
-pub struct NeutronNovaVerifierKey<E: Engine> {
+pub struct VegaMcVerifierKey<E: Engine> {
   ck: CommitmentKey<E>,
   vk_ee: <E::PCS as PCSEngineTrait<E>>::VerifierKey,
   S_step: SplitR1CSShape<E>,
@@ -1299,10 +1292,10 @@ pub struct NeutronNovaVerifierKey<E: Engine> {
   vc_ck: CommitmentKey<E>,
   vc_vk: VerifierKey<E>,
   #[serde(skip, default = "OnceCell::new")]
-  digest: OnceCell<SpartanDigest>,
+  digest: OnceCell<VegaDigest>,
 }
 
-impl<E: Engine> crate::digest::Digestible for NeutronNovaVerifierKey<E> {
+impl<E: Engine> crate::digest::Digestible for VegaMcVerifierKey<E> {
   fn write_bytes<W: Sized + std::io::Write>(&self, w: &mut W) -> Result<(), std::io::Error> {
     use bincode::Options;
     let config = bincode::DefaultOptions::new()
@@ -1334,9 +1327,9 @@ impl<E: Engine> crate::digest::Digestible for NeutronNovaVerifierKey<E> {
   }
 }
 
-impl<E: Engine> DigestHelperTrait<E> for NeutronNovaVerifierKey<E> {
+impl<E: Engine> DigestHelperTrait<E> for VegaMcVerifierKey<E> {
   /// Returns the digest of the verifier's key.
-  fn digest(&self) -> Result<SpartanDigest, SpartanError> {
+  fn digest(&self) -> Result<VegaDigest, VegaError> {
     self
       .digest
       .get_or_try_init(|| {
@@ -1344,8 +1337,8 @@ impl<E: Engine> DigestHelperTrait<E> for NeutronNovaVerifierKey<E> {
         dc.digest()
       })
       .cloned()
-      .map_err(|_| SpartanError::DigestError {
-        reason: "Unable to compute digest for SpartanVerifierKey".to_string(),
+      .map_err(|_| VegaError::DigestError {
+        reason: "Unable to compute digest for VegaVerifierKey".to_string(),
       })
   }
 }
@@ -1353,7 +1346,7 @@ impl<E: Engine> DigestHelperTrait<E> for NeutronNovaVerifierKey<E> {
 /// A type that holds the pre-processed state for proving
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(bound = "")]
-pub struct NeutronNovaPrepZkSNARK<E: Engine> {
+pub struct VegaMcPrepZkSNARK<E: Engine> {
   ps_step: Vec<PrecommittedState<E>>,
   ps_core: PrecommittedState<E>,
   /// Cached partial matrix-vector products for shared+precommitted columns per step circuit (deterministic).
@@ -1372,7 +1365,7 @@ pub struct NeutronNovaPrepZkSNARK<E: Engine> {
 /// Holds the proof produced by the NeutronNova folding scheme followed by NeutronNova SNARK
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(bound = "")]
-pub struct NeutronNovaZkSNARK<E: Engine> {
+pub struct VegaMcZkSNARK<E: Engine> {
   /// Shared commitment stored once (same for all step instances and core).
   comm_W_shared: Option<Commitment<E>>,
   step_instances: Vec<SplitR1CSInstance<E>>,
@@ -1384,7 +1377,7 @@ pub struct NeutronNovaZkSNARK<E: Engine> {
   relaxed_snark: crate::spartan_relaxed::RelaxedR1CSSpartanProof<E>,
 }
 
-impl<E: Engine> NeutronNovaZkSNARK<E>
+impl<E: Engine> VegaMcZkSNARK<E>
 where
   E::PCS: FoldingEngineTrait<E>,
 {
@@ -1394,11 +1387,11 @@ where
   /// - `step_circuit`: The circuit to be folded in the batch
   /// - `core_circuit`: The core circuit that connects the batch together
   /// - `num_steps`: The number of step circuits in the batch (will be padded to next power of two internally)
-  pub fn setup<C1: SpartanCircuit<E>, C2: SpartanCircuit<E>>(
+  pub fn setup<C1: VegaCircuit<E>, C2: VegaCircuit<E>>(
     step_circuit: &C1,
     core_circuit: &C2,
     num_steps: usize,
-  ) -> Result<(NeutronNovaProverKey<E>, NeutronNovaVerifierKey<E>), SpartanError> {
+  ) -> Result<(VegaMcProverKey<E>, VegaMcVerifierKey<E>), VegaError> {
     let (_setup_span, setup_t) = start_span!("neutronnova_setup");
 
     let (_r1cs_span, r1cs_t) = start_span!("r1cs_shape_generation");
@@ -1434,14 +1427,14 @@ where
     let num_vars = S_step.num_shared + S_step.num_precommitted + S_step.num_rest;
     let num_rounds_x = usize::try_from(S_step.num_cons.ilog2()).unwrap();
     let num_rounds_y = usize::try_from(num_vars.ilog2()).unwrap() + 1;
-    let vc = NeutronNovaVerifierCircuit::<E>::default(num_rounds_b, num_rounds_x, num_rounds_y, 32);
+    let vc = VegaMcVerifierCircuit::<E>::default(num_rounds_b, num_rounds_x, num_rounds_y, 32);
     let (vc_shape, vc_ck, vc_vk) =
-      <ShapeCS<E> as MultiRoundSpartanShape<E>>::multiround_r1cs_shape(&vc)?;
+      <ShapeCS<E> as MultiRoundVegaShape<E>>::multiround_r1cs_shape(&vc)?;
     let vc_shape_regular = vc_shape.to_regular_shape();
     info!(elapsed_ms = %vc_t.elapsed().as_millis(), "verifier_circuit_setup");
     // Eagerly init FixedBaseMul table before cloning so both pk/vk get it
     E::PCS::precompute_ck(&vc_ck);
-    let vk: NeutronNovaVerifierKey<E> = NeutronNovaVerifierKey {
+    let vk: VegaMcVerifierKey<E> = VegaMcVerifierKey {
       ck: ck.clone(),
       S_step: S_step.clone(),
       S_core: S_core.clone(),
@@ -1454,7 +1447,7 @@ where
     };
 
     let vk_digest = vk.digest()?;
-    let pk = NeutronNovaProverKey {
+    let pk = VegaMcProverKey {
       ck,
       S_step,
       S_core,
@@ -1474,12 +1467,12 @@ where
   }
 
   /// Prepares the pre-processed state for proving
-  pub fn prep_prove<C1: SpartanCircuit<E>, C2: SpartanCircuit<E>>(
-    pk: &NeutronNovaProverKey<E>,
+  pub fn prep_prove<C1: VegaCircuit<E>, C2: VegaCircuit<E>>(
+    pk: &VegaMcProverKey<E>,
     step_circuits: &[C1],
     core_circuit: &C2,
     is_small: bool, // do witness elements fit in machine words?
-  ) -> Result<NeutronNovaPrepZkSNARK<E>, SpartanError> {
+  ) -> Result<VegaMcPrepZkSNARK<E>, VegaError> {
     let (_prep_span, prep_t) = start_span!("neutronnova_prep_prove");
 
     // we synthesize shared witness for the first circuit; every other circuit including the core circuit shares this witness
@@ -1529,7 +1522,7 @@ where
         let step_public_values: Vec<Vec<E::Scalar>> = step_circuits
           .iter()
           .map(|c| {
-            c.public_values().map_err(|e| SpartanError::SynthesisError {
+            c.public_values().map_err(|e| VegaError::SynthesisError {
               reason: format!("Circuit does not provide public IO: {e}"),
             })
           })
@@ -1592,7 +1585,7 @@ where
       };
 
     info!(elapsed_ms = %prep_t.elapsed().as_millis(), "neutronnova_prep_prove");
-    Ok(NeutronNovaPrepZkSNARK {
+    Ok(VegaMcPrepZkSNARK {
       ps_step,
       ps_core: ps,
       cached_step_matvec,
@@ -1606,13 +1599,13 @@ where
   /// Takes ownership of `prep_snark` to avoid cloning large witness vectors (~66MB).
   /// Returns the proof and the (consumed) prep state, which can be passed to prove again
   /// after re-running prep_prove or simply re-rerandomized.
-  pub fn prove<C1: SpartanCircuit<E>, C2: SpartanCircuit<E>>(
-    pk: &NeutronNovaProverKey<E>,
+  pub fn prove<C1: VegaCircuit<E>, C2: VegaCircuit<E>>(
+    pk: &VegaMcProverKey<E>,
     step_circuits: &[C1],
     core_circuit: &C2,
-    mut prep_snark: NeutronNovaPrepZkSNARK<E>,
+    mut prep_snark: VegaMcPrepZkSNARK<E>,
     is_small: bool, // do witness elements fit in machine words?
-  ) -> Result<(Self, NeutronNovaPrepZkSNARK<E>), SpartanError> {
+  ) -> Result<(Self, VegaMcPrepZkSNARK<E>), VegaError> {
     let (_prove_span, prove_t) = start_span!("neutronnova_prove");
 
     // rerandomize prep state in-place (we own it, no clone needed)
@@ -1632,7 +1625,7 @@ where
     // if the circuits changed, the cache is stale and would produce incorrect proofs.
     if !prep_snark.cached_step_public_values.is_empty() {
       if prep_snark.cached_step_public_values.len() != step_circuits.len() {
-        return Err(SpartanError::InternalError {
+        return Err(VegaError::InternalError {
           reason: format!(
             "Cached matvec was computed for {} step circuits, but prove received {}",
             prep_snark.cached_step_public_values.len(),
@@ -1643,11 +1636,11 @@ where
       for (i, circuit) in step_circuits.iter().enumerate() {
         let current_pv = circuit
           .public_values()
-          .map_err(|e| SpartanError::SynthesisError {
+          .map_err(|e| VegaError::SynthesisError {
             reason: format!("Circuit does not provide public IO: {e}"),
           })?;
         if prep_snark.cached_step_public_values[i] != current_pv {
-          return Err(SpartanError::InternalError {
+          return Err(VegaError::InternalError {
             reason: format!("Step circuit {i} public values changed between prep_prove and prove"),
           });
         }
@@ -1674,12 +1667,11 @@ where
             );
             transcript.absorb(b"circuit_index", &E::Scalar::from(i as u64));
 
-            let public_values =
-              circuit
-                .public_values()
-                .map_err(|e| SpartanError::SynthesisError {
-                  reason: format!("Circuit does not provide public IO: {e}"),
-                })?;
+            let public_values = circuit
+              .public_values()
+              .map_err(|e| VegaError::SynthesisError {
+                reason: format!("Circuit does not provide public IO: {e}"),
+              })?;
             transcript.absorb(b"public_values", &public_values.as_slice());
 
             SatisfyingAssignment::r1cs_instance_and_witness(
@@ -1703,7 +1695,7 @@ where
         let public_values_core =
           core_circuit
             .public_values()
-            .map_err(|e| SpartanError::SynthesisError {
+            .map_err(|e| VegaError::SynthesisError {
               reason: format!("Core circuit does not provide public IO: {e}"),
             })?;
         transcript.absorb(b"public_values", &public_values_core.as_slice());
@@ -1743,7 +1735,7 @@ where
     let num_rounds_x = pk.S_step.num_cons.log_2();
     let num_rounds_y = num_vars.log_2() + 1;
 
-    let mut vc = NeutronNovaVerifierCircuit::<E>::default(
+    let mut vc = VegaMcVerifierCircuit::<E>::default(
       num_rounds_b,
       num_rounds_x,
       num_rounds_y,
@@ -1767,7 +1759,7 @@ where
       .cached_step_i64
       .as_ref()
       .map(|v| v.par_iter().cloned().collect::<Vec<_>>());
-    let (E_eq, Az_step, Bz_step, Cz_step, folded_W, folded_U) = NeutronNovaNIFS::<E>::prove(
+    let (E_eq, Az_step, Bz_step, Cz_step, folded_W, folded_U) = VegaMcNIFS::<E>::prove(
       &pk.S_step,
       &pk.ck,
       step_instances_regular,
@@ -1947,7 +1939,7 @@ where
       SparsePolynomial::new(num_vars_log2, X).evaluate(&r_y[1..])
     };
     let inv: Option<E::Scalar> = (E::Scalar::ONE - r_y[0]).invert().into();
-    let one_minus_ry0_inv = inv.ok_or(SpartanError::DivisionByZero)?;
+    let one_minus_ry0_inv = inv.ok_or(VegaError::DivisionByZero)?;
     let eval_W_step = (eval_Z_step - r_y[0] * eval_X_step) * one_minus_ry0_inv;
     let eval_W_core = (eval_Z_core - r_y[0] * eval_X_core) * one_minus_ry0_inv;
 
@@ -2092,15 +2084,15 @@ where
     Ok((result, prep_snark))
   }
 
-  /// Verifies the NeutronNovaZkSNARK and returns the public IO from the instances
+  /// Verifies the VegaMcZkSNARK and returns the public IO from the instances
   pub fn verify(
     &self,
-    vk: &NeutronNovaVerifierKey<E>,
+    vk: &VegaMcVerifierKey<E>,
     num_instances: usize,
-  ) -> Result<(Vec<Vec<E::Scalar>>, Vec<E::Scalar>), SpartanError> {
+  ) -> Result<(Vec<Vec<E::Scalar>>, Vec<E::Scalar>), VegaError> {
     let (_verify_span, _verify_t) = start_span!("neutronnova_verify");
     if num_instances == 0 || num_instances != self.step_instances.len() {
-      return Err(SpartanError::ProofVerifyError {
+      return Err(VegaError::ProofVerifyError {
         reason: format!(
           "Expected {} instances (non-zero), got {}",
           num_instances,
@@ -2152,7 +2144,7 @@ where
     // also verify it matches the core instance
     for u in &step_instances {
       if u.comm_W_shared != core_instance.comm_W_shared {
-        return Err(SpartanError::ProofVerifyError {
+        return Err(VegaError::ProofVerifyError {
           reason: "All instances must have the same shared commitment".to_string(),
         });
       }
@@ -2205,7 +2197,7 @@ where
     let num_public_values = 6usize;
     let num_challenges = num_rounds_b + num_rounds_x + 1 + num_rounds_y;
     if U_verifier_regular.X.len() != num_challenges + num_public_values {
-      return Err(SpartanError::ProofVerifyError {
+      return Err(VegaError::ProofVerifyError {
         reason: format!(
           "Verifier instance has incorrect number of public IO: expected {}, got {}",
           num_challenges + num_public_values,
@@ -2241,7 +2233,7 @@ where
         &folded_U_verifier,
         &mut transcript,
       )
-      .map_err(|e| SpartanError::ProofVerifyError {
+      .map_err(|e| VegaError::ProofVerifyError {
         reason: format!("Relaxed Spartan verify failed: {e}"),
       })?;
     let (_matrix_eval_span, matrix_eval_t) = start_span!("matrix_evaluations");
@@ -2292,7 +2284,7 @@ where
       || public_values[4] != quotient_step
       || public_values[5] != quotient_core
     {
-      return Err(SpartanError::ProofVerifyError {
+      return Err(VegaError::ProofVerifyError {
         reason:
           "Verifier instance public tau_at_rx/eval_X_step/eq_rho_at_rb/eval_X_core/quotients do not match recomputation"
             .to_string(),
@@ -2360,7 +2352,7 @@ mod tests {
     _p: PhantomData<E>,
   }
 
-  impl<E: Engine> SpartanCircuit<E> for Sha256Circuit<E> {
+  impl<E: Engine> VegaCircuit<E> for Sha256Circuit<E> {
     fn public_values(&self) -> Result<Vec<E::Scalar>, SynthesisError> {
       Ok(vec![E::Scalar::ZERO]) // Placeholder, we don't use public values in this example
     }
@@ -2421,8 +2413,8 @@ mod tests {
     num_circuits: usize,
     len: usize,
   ) -> (
-    NeutronNovaProverKey<E>,
-    NeutronNovaVerifierKey<E>,
+    VegaMcProverKey<E>,
+    VegaMcVerifierKey<E>,
     Vec<Sha256Circuit<E>>,
   )
   where
@@ -2433,7 +2425,7 @@ mod tests {
       _p: Default::default(),
     };
 
-    let (pk, vk) = NeutronNovaZkSNARK::<E>::setup(&circuit, &circuit, num_circuits).unwrap();
+    let (pk, vk) = VegaMcZkSNARK::<E>::setup(&circuit, &circuit, num_circuits).unwrap();
 
     let circuits = (0..num_circuits)
       .map(|i| Sha256Circuit::<E> {
@@ -2445,10 +2437,10 @@ mod tests {
     (pk, vk, circuits)
   }
 
-  fn test_neutron_inner<E: Engine, C1: SpartanCircuit<E>, C2: SpartanCircuit<E>>(
+  fn test_neutron_inner<E: Engine, C1: VegaCircuit<E>, C2: VegaCircuit<E>>(
     name: &str,
-    pk: &NeutronNovaProverKey<E>,
-    vk: &NeutronNovaVerifierKey<E>,
+    pk: &VegaMcProverKey<E>,
+    vk: &VegaMcVerifierKey<E>,
     step_circuits: &[C1],
     core_circuit: &C2,
   ) where
@@ -2459,8 +2451,8 @@ mod tests {
       step_circuits.len()
     );
 
-    let ps = NeutronNovaZkSNARK::<E>::prep_prove(pk, step_circuits, core_circuit, true).unwrap();
-    let res = NeutronNovaZkSNARK::prove(pk, step_circuits, core_circuit, ps, true);
+    let ps = VegaMcZkSNARK::<E>::prep_prove(pk, step_circuits, core_circuit, true).unwrap();
+    let res = VegaMcZkSNARK::prove(pk, step_circuits, core_circuit, ps, true);
     assert!(res.is_ok());
 
     let (snark, _ps) = res.unwrap();

--- a/src/vega_mc_zkp.rs
+++ b/src/vega_mc_zkp.rs
@@ -4,7 +4,7 @@
 // See the LICENSE file in the project root for full license information.
 // Source repository: https://github.com/Microsoft/vega-prover
 
-//! Multi-circuit (MC) prover using NeutronNova folding (https://eprint.iacr.org/2024/1606), proved with the single-circuit prover.
+//! Zero-knowledge multi-circuit (MC) prover using NeutronNova folding (https://eprint.iacr.org/2024/1606), proved with the single-circuit prover.
 use crate::start_span;
 use crate::{
   Commitment, CommitmentKey, DEFAULT_COMMITMENT_WIDTH, VerifierKey,
@@ -1362,7 +1362,7 @@ pub struct VegaMcPrepZkSNARK<E: Engine> {
   cached_step_public_values: Vec<Vec<E::Scalar>>,
 }
 
-/// Holds the proof produced by the NeutronNova folding scheme followed by NeutronNova SNARK
+/// Holds the zero-knowledge proof produced by the NeutronNova folding scheme followed by NeutronNova SNARK
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(bound = "")]
 pub struct VegaMcZkSNARK<E: Engine> {

--- a/src/vega_sc.rs
+++ b/src/vega_sc.rs
@@ -1,21 +1,20 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
-// This file is part of the Spartan2 project.
+// This file is part of the vega-prover project.
 // See the LICENSE file in the project root for full license information.
-// Source repository: https://github.com/Microsoft/Spartan2
+// Source repository: https://github.com/Microsoft/vega-prover
 
-//! This module implements the Spartan SNARK protocol.
-//! It provides the prover and verifier keys, as well as the SNARK itself.
+//! Single-circuit (SC) prover. Implements the Spartan SNARK protocol (https://eprint.iacr.org/2019/550).
 use crate::{
   Blind, CommitmentKey,
   bellpepper::{
-    r1cs::{PrecommittedState, SpartanShape, SpartanWitness},
+    r1cs::{PrecommittedState, VegaShape, VegaWitness},
     shape_cs::ShapeCS,
     solver::SatisfyingAssignment,
   },
   big_num::DelayedReduction,
   digest::DigestComputer,
-  errors::SpartanError,
+  errors::VegaError,
   math::Math,
   polys::{
     eq::EqPolynomial,
@@ -27,9 +26,9 @@ use crate::{
   sumcheck::SumcheckProof,
   traits::{
     Engine,
-    circuit::SpartanCircuit,
+    circuit::VegaCircuit,
     pcs::PCSEngineTrait,
-    snark::{DigestHelperTrait, R1CSSNARKTrait, SpartanDigest},
+    snark::{DigestHelperTrait, R1CSSNARKTrait, VegaDigest},
     transcript::TranscriptEngineTrait,
   },
 };
@@ -41,14 +40,14 @@ use tracing::info;
 /// A type that represents the prover's key
 #[derive(Serialize, Deserialize)]
 #[serde(bound = "")]
-pub struct SpartanProverKey<E: Engine> {
+pub struct VegaProverKey<E: Engine> {
   ck: CommitmentKey<E>,
   ck_s: CommitmentKey<E>,
   S: SplitR1CSShape<E>,
-  vk_digest: SpartanDigest, // digest of the verifier's key
+  vk_digest: VegaDigest, // digest of the verifier's key
 }
 
-impl<E: Engine> SpartanProverKey<E> {
+impl<E: Engine> VegaProverKey<E> {
   /// Returns sizes associated with the SplitR1CSShape.
   /// It returns an array of 10 elements containing:
   /// [num_cons_unpadded, num_shared_unpadded, num_precommitted_unpadded, num_rest_unpadded,
@@ -62,15 +61,15 @@ impl<E: Engine> SpartanProverKey<E> {
 /// A type that represents the verifier's key
 #[derive(Serialize, Deserialize)]
 #[serde(bound = "")]
-pub struct SpartanVerifierKey<E: Engine> {
+pub struct VegaVerifierKey<E: Engine> {
   vk_ee: <E::PCS as PCSEngineTrait<E>>::VerifierKey,
   ck_s: CommitmentKey<E>,
   S: SplitR1CSShape<E>,
   #[serde(skip, default = "OnceCell::new")]
-  digest: OnceCell<SpartanDigest>,
+  digest: OnceCell<VegaDigest>,
 }
 
-impl<E: Engine> crate::digest::Digestible for SpartanVerifierKey<E> {
+impl<E: Engine> crate::digest::Digestible for VegaVerifierKey<E> {
   fn write_bytes<W: Sized + std::io::Write>(&self, w: &mut W) -> Result<(), std::io::Error> {
     use bincode::Options;
     let config = bincode::DefaultOptions::new()
@@ -87,9 +86,9 @@ impl<E: Engine> crate::digest::Digestible for SpartanVerifierKey<E> {
   }
 }
 
-impl<E: Engine> DigestHelperTrait<E> for SpartanVerifierKey<E> {
+impl<E: Engine> DigestHelperTrait<E> for VegaVerifierKey<E> {
   /// Returns the digest of the verifier's key.
-  fn digest(&self) -> Result<SpartanDigest, SpartanError> {
+  fn digest(&self) -> Result<VegaDigest, VegaError> {
     self
       .digest
       .get_or_try_init(|| {
@@ -97,8 +96,8 @@ impl<E: Engine> DigestHelperTrait<E> for SpartanVerifierKey<E> {
         dc.digest()
       })
       .cloned()
-      .map_err(|_| SpartanError::DigestError {
-        reason: "Unable to compute digest for SpartanVerifierKey".to_string(),
+      .map_err(|_| VegaError::DigestError {
+        reason: "Unable to compute digest for VegaVerifierKey".to_string(),
       })
   }
 }
@@ -106,7 +105,7 @@ impl<E: Engine> DigestHelperTrait<E> for SpartanVerifierKey<E> {
 /// A type that holds the pre-processed state for proving
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(bound = "")]
-pub struct SpartanPrepSNARK<E: Engine> {
+pub struct VegaPrepSNARK<E: Engine> {
   ps: PrecommittedState<E>,
   // Cached partial matrix-vector products for precommitted witness columns (deterministic)
   cached_az: Vec<E::Scalar>,
@@ -128,7 +127,7 @@ pub struct SpartanPrepSNARK<E: Engine> {
 /// the commitment to a vector viewed as a polynomial commitment
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(bound = "")]
-pub struct SpartanSNARK<E: Engine> {
+pub struct VegaSNARK<E: Engine> {
   U: SplitR1CSInstance<E>,
   sc_proof_outer: SumcheckProof<E>,
   claims_outer: (E::Scalar, E::Scalar, E::Scalar),
@@ -138,21 +137,21 @@ pub struct SpartanSNARK<E: Engine> {
   eval_arg: <E::PCS as PCSEngineTrait<E>>::EvaluationArgument,
 }
 
-impl<E: Engine> R1CSSNARKTrait<E> for SpartanSNARK<E> {
-  type ProverKey = SpartanProverKey<E>;
-  type VerifierKey = SpartanVerifierKey<E>;
-  type PrepSNARK = SpartanPrepSNARK<E>;
+impl<E: Engine> R1CSSNARKTrait<E> for VegaSNARK<E> {
+  type ProverKey = VegaProverKey<E>;
+  type VerifierKey = VegaVerifierKey<E>;
+  type PrepSNARK = VegaPrepSNARK<E>;
 
-  fn setup<C: SpartanCircuit<E>>(
+  fn setup<C: VegaCircuit<E>>(
     circuit: C,
-  ) -> Result<(Self::ProverKey, Self::VerifierKey), SpartanError> {
+  ) -> Result<(Self::ProverKey, Self::VerifierKey), VegaError> {
     let S = ShapeCS::r1cs_shape(&circuit)?;
     let (ck, vk_ee) = SplitR1CSShape::commitment_key(&[&S])?;
     E::PCS::precompute_ck(&ck);
     let (ck_s, _) = E::PCS::setup(b"ck_s", 1, 1); // 1 base for committing a single scalar
     E::PCS::precompute_ck(&ck_s);
 
-    let vk: SpartanVerifierKey<E> = SpartanVerifierKey {
+    let vk: VegaVerifierKey<E> = VegaVerifierKey {
       S: S.clone(),
       vk_ee,
       ck_s: ck_s.clone(),
@@ -173,11 +172,11 @@ impl<E: Engine> R1CSSNARKTrait<E> for SpartanSNARK<E> {
   }
 
   /// Prepares the SNARK for proving
-  fn prep_prove<C: SpartanCircuit<E>>(
+  fn prep_prove<C: VegaCircuit<E>>(
     pk: &Self::ProverKey,
     circuit: C,
     is_small: bool, // do witness elements fit in machine words?
-  ) -> Result<Self::PrepSNARK, SpartanError> {
+  ) -> Result<Self::PrepSNARK, VegaError> {
     let mut ps = SatisfyingAssignment::shared_witness(&pk.S, &pk.ck, &circuit, is_small)?;
     SatisfyingAssignment::precommitted_witness(&mut ps, &pk.S, &pk.ck, &circuit, is_small)?;
 
@@ -200,7 +199,7 @@ impl<E: Engine> R1CSSNARKTrait<E> for SpartanSNARK<E> {
     let z_buffer = vec![E::Scalar::ZERO; num_z];
     let evals_rx_buffer = Vec::with_capacity(num_cons);
 
-    Ok(SpartanPrepSNARK {
+    Ok(VegaPrepSNARK {
       ps,
       cached_az,
       cached_bz,
@@ -216,19 +215,19 @@ impl<E: Engine> R1CSSNARKTrait<E> for SpartanSNARK<E> {
   }
 
   /// produces a succinct proof of satisfiability of an R1CS instance
-  fn prove<C: SpartanCircuit<E>>(
+  fn prove<C: VegaCircuit<E>>(
     pk: &Self::ProverKey,
     circuit: C,
     mut prep_snark: Self::PrepSNARK,
     is_small: bool,
-  ) -> Result<(Self, Self::PrepSNARK), SpartanError> {
+  ) -> Result<(Self, Self::PrepSNARK), VegaError> {
     let (_prove_span, prove_t) = start_span!("spartan_snark_prove");
-    let mut transcript = E::TE::new(b"SpartanSNARK");
+    let mut transcript = E::TE::new(b"VegaSNARK");
     transcript.absorb(b"vk", &pk.vk_digest);
 
     let public_values = circuit
       .public_values()
-      .map_err(|e| SpartanError::SynthesisError {
+      .map_err(|e| VegaError::SynthesisError {
         reason: format!("Circuit does not provide public IO: {e}"),
       })?;
 
@@ -261,7 +260,7 @@ impl<E: Engine> R1CSSNARKTrait<E> for SpartanSNARK<E> {
     // outer sum-check preparation
     let tau = (0..num_rounds_x)
       .map(|_i| transcript.squeeze(b"t"))
-      .collect::<Result<Vec<_>, SpartanError>>()?;
+      .collect::<Result<Vec<_>, VegaError>>()?;
 
     // Use incremental matvec with cached precommitted products and scratch buffers
     let (_mv_span, mv_t) = start_span!("matrix_vector_multiply");
@@ -418,7 +417,7 @@ impl<E: Engine> R1CSSNARKTrait<E> for SpartanSNARK<E> {
       SparsePolynomial::new(num_rounds_y - 1, X).evaluate(&r_y[1..])
     };
     let inv: Option<E::Scalar> = (E::Scalar::ONE - r_y[0]).invert().into();
-    let eval_W = (eval_Z - r_y[0] * eval_X) * inv.ok_or(SpartanError::DivisionByZero)?;
+    let eval_W = (eval_Z - r_y[0] * eval_X) * inv.ok_or(VegaError::DivisionByZero)?;
 
     let (_pcs_span, pcs_t) = start_span!("pcs_prove");
     let blind_eval_W = E::PCS::blind(&pk.ck_s, 1);
@@ -438,7 +437,7 @@ impl<E: Engine> R1CSSNARKTrait<E> for SpartanSNARK<E> {
 
     info!(elapsed_ms = %prove_t.elapsed().as_millis(), "spartan_snark_prove");
     // Return proof and updated prep state with preserved scratch buffers
-    let updated_prep = SpartanPrepSNARK {
+    let updated_prep = VegaPrepSNARK {
       ps: prep_snark.ps,
       cached_az: prep_snark.cached_az,
       cached_bz: prep_snark.cached_bz,
@@ -452,7 +451,7 @@ impl<E: Engine> R1CSSNARKTrait<E> for SpartanSNARK<E> {
       evals_rx_buffer,
     };
     Ok((
-      SpartanSNARK {
+      VegaSNARK {
         U,
         sc_proof_outer,
         claims_outer: (claim_Az, claim_Bz, claim_Cz),
@@ -466,9 +465,9 @@ impl<E: Engine> R1CSSNARKTrait<E> for SpartanSNARK<E> {
   }
 
   /// verifies a proof of satisfiability of a `RelaxedR1CS` instance
-  fn verify(&self, vk: &Self::VerifierKey) -> Result<Vec<E::Scalar>, SpartanError> {
+  fn verify(&self, vk: &Self::VerifierKey) -> Result<Vec<E::Scalar>, VegaError> {
     let (_verify_span, verify_t) = start_span!("spartan_snark_verify");
-    let mut transcript = E::TE::new(b"SpartanSNARK");
+    let mut transcript = E::TE::new(b"VegaSNARK");
 
     // append the digest of R1CS matrices
     transcript.absorb(b"vk", &vk.digest()?);
@@ -494,7 +493,7 @@ impl<E: Engine> R1CSSNARKTrait<E> for SpartanSNARK<E> {
     let (_tau_span, tau_t) = start_span!("compute_tau_verify");
     let tau = (0..num_rounds_x)
       .map(|_i| transcript.squeeze(b"t"))
-      .collect::<Result<EqPolynomial<_>, SpartanError>>()?;
+      .collect::<Result<EqPolynomial<_>, VegaError>>()?;
     info!(elapsed_ms = %tau_t.elapsed().as_millis(), "compute_tau_verify");
 
     let (_outer_sumcheck_span, outer_sumcheck_t) = start_span!("outer_sumcheck_verify");
@@ -508,7 +507,7 @@ impl<E: Engine> R1CSSNARKTrait<E> for SpartanSNARK<E> {
     let taus_bound_rx = tau.evaluate(&r_x);
     let claim_outer_final_expected = taus_bound_rx * (claim_Az * claim_Bz - claim_Cz);
     if claim_outer_final != claim_outer_final_expected {
-      return Err(SpartanError::InvalidSumcheckProof);
+      return Err(VegaError::InvalidSumcheckProof);
     }
     info!(elapsed_ms = %outer_sumcheck_t.elapsed().as_millis(), "outer_sumcheck_verify");
 
@@ -554,7 +553,7 @@ impl<E: Engine> R1CSSNARKTrait<E> for SpartanSNARK<E> {
 
     let claim_inner_final_expected = (eval_A + r * eval_B + r * r * eval_C) * eval_Z;
     if claim_inner_final != claim_inner_final_expected {
-      return Err(SpartanError::InvalidSumcheckProof);
+      return Err(VegaError::InvalidSumcheckProof);
     }
     info!(elapsed_ms = %matrix_eval_t.elapsed().as_millis(), "matrix_evaluations");
     info!(elapsed_ms = %inner_sumcheck_t.elapsed().as_millis(), "inner_sumcheck_verify");
@@ -587,7 +586,7 @@ mod tests {
   #[derive(Clone, Debug, Default)]
   struct CubicCircuit {}
 
-  impl<E: Engine> SpartanCircuit<E> for CubicCircuit {
+  impl<E: Engine> VegaCircuit<E> for CubicCircuit {
     fn public_values(&self) -> Result<Vec<<E as Engine>::Scalar>, SynthesisError> {
       Ok(vec![E::Scalar::from(15u64)])
     }
@@ -659,11 +658,11 @@ mod tests {
         .try_init();
 
     type E = crate::provider::PallasHyraxEngine;
-    type S = SpartanSNARK<E>;
+    type S = VegaSNARK<E>;
     test_snark_with::<E, S>();
 
     type E2 = crate::provider::T256HyraxEngine;
-    type S2 = SpartanSNARK<E2>;
+    type S2 = VegaSNARK<E2>;
     test_snark_with::<E2, S2>();
   }
 

--- a/src/vega_sc_zkp.rs
+++ b/src/vega_sc_zkp.rs
@@ -1,24 +1,20 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
-// This file is part of the Spartan2 project.
+// This file is part of the vega-prover project.
 // See the LICENSE file in the project root for full license information.
-// Source repository: https://github.com/Microsoft/Spartan2
+// Source repository: https://github.com/Microsoft/vega-prover
 
-//! This module implements the Spartan zkSNARK protocol. We provide zero-knowledge via Nova's folding scheme
-//! It provides the prover and verifier keys, as well as the zkSNARK itself.
+//! Zero-knowledge single-circuit (SC) prover. Implements the Spartan protocol with Nova folding for ZK.
 use crate::{
   CommitmentKey, PCS, VerifierKey,
   bellpepper::{
-    r1cs::{
-      MultiRoundSpartanShape, MultiRoundSpartanWitness, PrecommittedState, SpartanShape,
-      SpartanWitness,
-    },
+    r1cs::{MultiRoundVegaShape, MultiRoundVegaWitness, PrecommittedState, VegaShape, VegaWitness},
     shape_cs::ShapeCS,
     solver::SatisfyingAssignment,
   },
   big_num::DelayedReduction,
   digest::DigestComputer,
-  errors::SpartanError,
+  errors::VegaError,
   math::Math,
   nifs::NovaNIFS,
   polys::{
@@ -34,12 +30,12 @@ use crate::{
   sumcheck::SumcheckProof,
   traits::{
     Engine,
-    circuit::SpartanCircuit,
+    circuit::VegaCircuit,
     pcs::{FoldingEngineTrait, PCSEngineTrait},
-    snark::{DigestHelperTrait, R1CSSNARKTrait, SpartanDigest},
+    snark::{DigestHelperTrait, R1CSSNARKTrait, VegaDigest},
     transcript::TranscriptEngineTrait,
   },
-  zk::SpartanVerifierCircuit,
+  zk::VegaVerifierCircuit,
 };
 use ff::Field;
 use once_cell::sync::OnceCell;
@@ -49,7 +45,7 @@ use tracing::info;
 /// A type that represents the prover's key
 #[derive(Serialize, Deserialize)]
 #[serde(bound = "")]
-pub struct SpartanProverKey<E: Engine> {
+pub struct VegaProverKey<E: Engine> {
   ck: CommitmentKey<E>,
   S: SplitR1CSShape<E>,
   // Verifier-circuit (multi-round) parameters
@@ -57,10 +53,10 @@ pub struct SpartanProverKey<E: Engine> {
   // Precomputed regular (single-round) verifier shape
   vc_shape_regular: R1CSShape<E>,
   vc_ck: CommitmentKey<E>,
-  vk_digest: SpartanDigest, // digest of the verifier's key
+  vk_digest: VegaDigest, // digest of the verifier's key
 }
 
-impl<E: Engine> SpartanProverKey<E> {
+impl<E: Engine> VegaProverKey<E> {
   /// Returns sizes associated with the SplitR1CSShape.
   /// It returns an array of 10 elements containing:
   /// [num_cons_unpadded, num_shared_unpadded, num_precommitted_unpadded, num_rest_unpadded,
@@ -74,7 +70,7 @@ impl<E: Engine> SpartanProverKey<E> {
 /// A type that represents the verifier's key
 #[derive(Serialize, Deserialize)]
 #[serde(bound = "")]
-pub struct SpartanVerifierKey<E: Engine> {
+pub struct VegaVerifierKey<E: Engine> {
   vk_ee: <E::PCS as PCSEngineTrait<E>>::VerifierKey,
   S: SplitR1CSShape<E>,
   // Verifier-circuit (multi-round) shape
@@ -86,10 +82,10 @@ pub struct SpartanVerifierKey<E: Engine> {
   // PCS verifier key for the verifier circuit (used by relaxed Spartan verify)
   vc_vk: VerifierKey<E>,
   #[serde(skip, default = "OnceCell::new")]
-  digest: OnceCell<SpartanDigest>,
+  digest: OnceCell<VegaDigest>,
 }
 
-impl<E: Engine> crate::digest::Digestible for SpartanVerifierKey<E> {
+impl<E: Engine> crate::digest::Digestible for VegaVerifierKey<E> {
   fn write_bytes<W: Sized + std::io::Write>(&self, w: &mut W) -> Result<(), std::io::Error> {
     use bincode::Options;
     let config = bincode::DefaultOptions::new()
@@ -117,9 +113,9 @@ impl<E: Engine> crate::digest::Digestible for SpartanVerifierKey<E> {
   }
 }
 
-impl<E: Engine> DigestHelperTrait<E> for SpartanVerifierKey<E> {
+impl<E: Engine> DigestHelperTrait<E> for VegaVerifierKey<E> {
   /// Returns the digest of the verifier's key.
-  fn digest(&self) -> Result<SpartanDigest, SpartanError> {
+  fn digest(&self) -> Result<VegaDigest, VegaError> {
     self
       .digest
       .get_or_try_init(|| {
@@ -127,8 +123,8 @@ impl<E: Engine> DigestHelperTrait<E> for SpartanVerifierKey<E> {
         dc.digest()
       })
       .cloned()
-      .map_err(|_| SpartanError::DigestError {
-        reason: "Unable to compute digest for SpartanVerifierKey".to_string(),
+      .map_err(|_| VegaError::DigestError {
+        reason: "Unable to compute digest for VegaVerifierKey".to_string(),
       })
   }
 }
@@ -136,7 +132,7 @@ impl<E: Engine> DigestHelperTrait<E> for SpartanVerifierKey<E> {
 /// A type that holds the pre-processed state for proving
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(bound = "")]
-pub struct SpartanPrepZkSNARK<E: Engine> {
+pub struct VegaPrepZkSNARK<E: Engine> {
   ps: PrecommittedState<E>,
   // Cached partial matrix-vector products for precommitted witness columns (deterministic)
   cached_az: Vec<E::Scalar>,
@@ -158,7 +154,7 @@ pub struct SpartanPrepZkSNARK<E: Engine> {
 /// This proof attests to knowledge of a witness satisfying the given R1CS constraints.
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(bound = "")]
-pub struct SpartanZkSNARK<E: Engine> {
+pub struct VegaZkSNARK<E: Engine> {
   /// Original R1CS instance
   U: SplitR1CSInstance<E>,
 
@@ -175,17 +171,17 @@ pub struct SpartanZkSNARK<E: Engine> {
   eval_arg: <E::PCS as PCSEngineTrait<E>>::EvaluationArgument,
 }
 
-impl<E: Engine> R1CSSNARKTrait<E> for SpartanZkSNARK<E>
+impl<E: Engine> R1CSSNARKTrait<E> for VegaZkSNARK<E>
 where
   E::PCS: FoldingEngineTrait<E>,
 {
-  type ProverKey = SpartanProverKey<E>;
-  type VerifierKey = SpartanVerifierKey<E>;
-  type PrepSNARK = SpartanPrepZkSNARK<E>;
+  type ProverKey = VegaProverKey<E>;
+  type VerifierKey = VegaVerifierKey<E>;
+  type PrepSNARK = VegaPrepZkSNARK<E>;
 
-  fn setup<C: SpartanCircuit<E>>(
+  fn setup<C: VegaCircuit<E>>(
     circuit: C,
-  ) -> Result<(Self::ProverKey, Self::VerifierKey), SpartanError> {
+  ) -> Result<(Self::ProverKey, Self::VerifierKey), VegaError> {
     let S = ShapeCS::r1cs_shape(&circuit)?;
     let (ck, vk_ee) = SplitR1CSShape::commitment_key(&[&S])?;
     E::PCS::precompute_ck(&ck);
@@ -193,9 +189,9 @@ where
     let num_vars = S.num_shared + S.num_precommitted + S.num_rest;
     let num_rounds_x = S.num_cons.log_2();
     let num_rounds_y = num_vars.log_2() + 1;
-    let vc = SpartanVerifierCircuit::<E>::default(num_rounds_x, num_rounds_y, 16);
+    let vc = VegaVerifierCircuit::<E>::default(num_rounds_x, num_rounds_y, 16);
     let (vc_shape, vc_ck, vc_vk) =
-      <ShapeCS<E> as MultiRoundSpartanShape<E>>::multiround_r1cs_shape(&vc)?;
+      <ShapeCS<E> as MultiRoundVegaShape<E>>::multiround_r1cs_shape(&vc)?;
     let vc_shape_regular = vc_shape.to_regular_shape();
     // Eagerly init FixedBaseMul table before cloning so both pk/vk get it
     E::PCS::precompute_ck(&vc_ck);
@@ -225,11 +221,11 @@ where
   }
 
   /// Prepares the SNARK for proving
-  fn prep_prove<C: SpartanCircuit<E>>(
+  fn prep_prove<C: VegaCircuit<E>>(
     pk: &Self::ProverKey,
     circuit: C,
     is_small: bool, // do witness elements fit in machine words?
-  ) -> Result<Self::PrepSNARK, SpartanError> {
+  ) -> Result<Self::PrepSNARK, VegaError> {
     let mut ps = SatisfyingAssignment::shared_witness(&pk.S, &pk.ck, &circuit, is_small)?;
     SatisfyingAssignment::precommitted_witness(&mut ps, &pk.S, &pk.ck, &circuit, is_small)?;
 
@@ -253,7 +249,7 @@ where
     let z_buffer = vec![E::Scalar::ZERO; num_z];
     let evals_rx_buffer = Vec::with_capacity(num_cons);
 
-    let prep = SpartanPrepZkSNARK {
+    let prep = VegaPrepZkSNARK {
       ps,
       cached_az,
       cached_bz,
@@ -272,23 +268,23 @@ where
 
   /// produces a succinct proof of satisfiability of an R1CS instance.
   /// Takes ownership of prep state, rerandomizes in-place, and returns it for reuse.
-  fn prove<C: SpartanCircuit<E>>(
+  fn prove<C: VegaCircuit<E>>(
     pk: &Self::ProverKey,
     circuit: C,
     mut prep_snark: Self::PrepSNARK,
     is_small: bool,
-  ) -> Result<(Self, Self::PrepSNARK), SpartanError> {
+  ) -> Result<(Self, Self::PrepSNARK), VegaError> {
     let (_prove_span, prove_t) = start_span!("spartan_zk_prove");
     // rerandomize the prep state in-place (we own it)
     let (_rerandomize_span, rerandomize_t) = start_span!("rerandomize_prep_state");
     prep_snark.ps.rerandomize_in_place(&pk.ck, &pk.S)?;
     info!(elapsed_ms = %rerandomize_t.elapsed().as_millis(), "rerandomize_prep_state");
-    let mut transcript = E::TE::new(b"SpartanZkSNARK");
+    let mut transcript = E::TE::new(b"VegaZkSNARK");
     transcript.absorb(b"vk", &pk.vk_digest);
     // absorb public IO before
     let public_values = circuit
       .public_values()
-      .map_err(|e| SpartanError::SynthesisError {
+      .map_err(|e| VegaError::SynthesisError {
         reason: format!("Circuit does not provide public IO: {e}"),
       })?;
     transcript.absorb(b"public_values", &public_values.as_slice());
@@ -306,7 +302,7 @@ where
 
     let challenges = (0..pk.S.num_challenges)
       .map(|_| transcript.squeeze(b"challenge"))
-      .collect::<Result<Vec<E::Scalar>, SpartanError>>()?;
+      .collect::<Result<Vec<E::Scalar>, VegaError>>()?;
 
     // Reset cs to prep-state size so synthesize appends to the right position
     let prep_aux_len = pk.S.num_shared_unpadded + pk.S.num_precommitted_unpadded;
@@ -321,7 +317,7 @@ where
         &prep_snark.ps.precommitted,
         Some(&challenges),
       )
-      .map_err(|e| SpartanError::SynthesisError {
+      .map_err(|e| VegaError::SynthesisError {
         reason: format!("Unable to synthesize witness: {e}"),
       })?;
     // Copy rest-witness into W
@@ -412,7 +408,7 @@ where
     let (_taus_span, taus_t) = start_span!("sample_taus");
     let taus = (0..num_rounds_x)
       .map(|_| transcript.squeeze(b"t"))
-      .collect::<Result<Vec<_>, SpartanError>>()?;
+      .collect::<Result<Vec<_>, VegaError>>()?;
     info!(elapsed_ms = %taus_t.elapsed().as_millis(), "sample_taus");
     // Use pre-allocated scratch buffers (avoids 96MB mmap + page faults after first prove)
     let (_mv_span, mv_t) = start_span!("matrix_vector_multiply");
@@ -439,11 +435,8 @@ where
     let mut poly_Cz = MultilinearPolynomial::new(scratch_cz);
     info!(elapsed_ms = %mp_t.elapsed().as_millis(), "prepare_multilinear_polys");
     // Initialize multi-round verifier circuit (will be filled as we go)
-    let mut verifier_circuit = SpartanVerifierCircuit::<E>::default(
-      num_rounds_x,
-      num_rounds_y,
-      pk.vc_shape.commitment_width,
-    );
+    let mut verifier_circuit =
+      VegaVerifierCircuit::<E>::default(num_rounds_x, num_rounds_y, pk.vc_shape.commitment_width);
     let mut state = SatisfyingAssignment::<E>::initialize_multiround_witness(&pk.vc_shape)?;
 
     // Outer sum-check
@@ -620,7 +613,7 @@ where
 
     // compute eval_W = (eval_Z - r_y[0] * eval_X) / (1 - r_y[0]) because Z = (W, 1, X)
     let inv: Option<E::Scalar> = (E::Scalar::ONE - r_y[0]).invert().into();
-    let eval_W = (eval_Z - r_y[0] * eval_X) * inv.ok_or(SpartanError::DivisionByZero)?;
+    let eval_W = (eval_Z - r_y[0] * eval_X) * inv.ok_or(VegaError::DivisionByZero)?;
 
     // Process the inner-final equality round
     // Set verifier circuit public values before processing inner-final round
@@ -694,7 +687,7 @@ where
 
     info!(elapsed_ms = %prove_t.elapsed().as_millis(), "spartan_zk_prove");
     // Return proof and updated prep state (deterministic caches only)
-    let updated_prep = SpartanPrepZkSNARK {
+    let updated_prep = VegaPrepZkSNARK {
       ps: prep_snark.ps,
       cached_az: prep_snark.cached_az,
       cached_bz: prep_snark.cached_bz,
@@ -708,7 +701,7 @@ where
       evals_rx_buffer,
     };
     Ok((
-      SpartanZkSNARK {
+      VegaZkSNARK {
         U_verifier,
         nifs,
         random_U,
@@ -721,10 +714,10 @@ where
   }
 
   /// verifies a proof of satisfiability of a `RelaxedR1CS` instance
-  fn verify(&self, vk: &Self::VerifierKey) -> Result<Vec<E::Scalar>, SpartanError> {
+  fn verify(&self, vk: &Self::VerifierKey) -> Result<Vec<E::Scalar>, VegaError> {
     // Verify by checking the multi-round verifier instance via NIFS folding
     let (_verify_span, verify_t) = start_span!("spartan_zk_verify");
-    let mut transcript = E::TE::new(b"SpartanZkSNARK");
+    let mut transcript = E::TE::new(b"VegaZkSNARK");
     transcript.absorb(b"vk", &vk.digest()?);
     transcript.absorb(b"public_values", &self.U.public_values.as_slice());
 
@@ -736,7 +729,7 @@ where
     let num_rounds_x = vk.S.num_cons.log_2();
     let tau = (0..num_rounds_x)
       .map(|_| transcript.squeeze(b"t"))
-      .collect::<Result<EqPolynomial<_>, SpartanError>>()?;
+      .collect::<Result<EqPolynomial<_>, VegaError>>()?;
     info!(elapsed_ms = %tau_t.elapsed().as_millis(), "compute_tau_verify");
     // validate the provided multi-round verifier instance and advance transcript
     self.U_verifier.validate(&vk.vc_shape, &mut transcript)?;
@@ -752,7 +745,7 @@ where
     let num_challenges = num_rounds_x + 1 + num_rounds_y;
 
     if U_verifier_regular.X.len() != num_challenges + num_public_values {
-      return Err(SpartanError::ProofVerifyError {
+      return Err(VegaError::ProofVerifyError {
         reason: format!(
           "Verifier instance has incorrect number of public IO: expected {}, got {}",
           num_challenges + num_public_values,
@@ -791,7 +784,7 @@ where
 
     // Compare against the instance's public inputs [tau_at_rx, eval_X, quotient]
     if public_values[0] != tau_at_rx || public_values[1] != eval_X || public_values[2] != quotient {
-      return Err(SpartanError::ProofVerifyError {
+      return Err(VegaError::ProofVerifyError {
         reason:
           "Verifier instance public values do not match recomputed evaluations (tau_at_rx, eval_X, quotient)"
             .to_string(),
@@ -808,7 +801,7 @@ where
     self
       .relaxed_snark
       .verify(&vk.vc_shape_regular, &vk.vc_vk, &folded_U, &mut transcript)
-      .map_err(|e| SpartanError::ProofVerifyError {
+      .map_err(|e| VegaError::ProofVerifyError {
         reason: format!("Relaxed Spartan verify failed: {e}"),
       })?;
     info!(elapsed_ms = %nifs_verify_t.elapsed().as_millis(), "nifs_verify");
@@ -849,7 +842,7 @@ mod tests {
   #[derive(Clone, Debug, Default)]
   struct CubicCircuit {}
 
-  impl<E: Engine> SpartanCircuit<E> for CubicCircuit {
+  impl<E: Engine> VegaCircuit<E> for CubicCircuit {
     fn public_values(&self) -> Result<Vec<<E as Engine>::Scalar>, SynthesisError> {
       Ok(vec![E::Scalar::from(15u64)])
     }
@@ -921,11 +914,11 @@ mod tests {
       .try_init();
 
     type E = crate::provider::PallasHyraxEngine;
-    type S = SpartanZkSNARK<E>;
+    type S = VegaZkSNARK<E>;
     test_zksnark_with::<E, S>();
 
     type E2 = crate::provider::T256HyraxEngine;
-    type S2 = SpartanZkSNARK<E2>;
+    type S2 = VegaZkSNARK<E2>;
     test_zksnark_with::<E2, S2>();
   }
 

--- a/src/vega_sc_zkp.rs
+++ b/src/vega_sc_zkp.rs
@@ -149,9 +149,9 @@ pub struct VegaPrepZkSNARK<E: Engine> {
   evals_rx_buffer: Vec<E::Scalar>,
 }
 
-/// A succinct non-interactive argument of knowledge (SNARK) for a relaxed R1CS instance,
+/// A zero-knowledge succinct non-interactive argument of knowledge (zkSNARK) for a relaxed R1CS instance,
 /// produced using Spartan's combination of sum-check protocols and polynomial commitments.
-/// This proof attests to knowledge of a witness satisfying the given R1CS constraints.
+/// This proof attests to knowledge of a witness satisfying the given R1CS constraints, without revealing the witness.
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(bound = "")]
 pub struct VegaZkSNARK<E: Engine> {
@@ -266,7 +266,7 @@ where
     Ok(prep)
   }
 
-  /// produces a succinct proof of satisfiability of an R1CS instance.
+  /// produces a zero-knowledge succinct proof of satisfiability of an R1CS instance.
   /// Takes ownership of prep state, rerandomizes in-place, and returns it for reuse.
   fn prove<C: VegaCircuit<E>>(
     pk: &Self::ProverKey,

--- a/src/zk.rs
+++ b/src/zk.rs
@@ -1,12 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
-// This file is part of the Spartan2 project.
+// This file is part of the vega-prover project.
 // See the LICENSE file in the project root for full license information.
-// Source repository: https://github.com/Microsoft/Spartan2
+// Source repository: https://github.com/Microsoft/vega-prover
 
 //! Zero-knowledge circuit implementing the algebraic checks of the Spartan verifier logic.
 //!
-//! [`SpartanVerifierCircuit`] constrains the complete Spartan verification across
+//! [`VegaVerifierCircuit`] constrains the complete Spartan verification across
 //! `outer_len + inner_len + 3` rounds: outer sum-check, inner sum-check, and bridging rounds.
 //!
 //! Note: This circuit only encodes the algebraic checks of the verifier. It does **not**
@@ -227,7 +227,7 @@ fn enforce_inner_sc_final_check<E: Engine, CS: ConstraintSystem<E::Scalar>>(
 
 /// Circuit constraining Spartan verifier computation across multiple rounds.
 #[derive(Clone, Debug)]
-pub struct SpartanVerifierCircuit<E: Engine> {
+pub struct VegaVerifierCircuit<E: Engine> {
   pub(crate) outer_polys: Vec<[E::Scalar; 4]>,
   pub(crate) claim_Az: E::Scalar,
   pub(crate) claim_Bz: E::Scalar,
@@ -239,7 +239,7 @@ pub struct SpartanVerifierCircuit<E: Engine> {
   pub(crate) mr_commitment_width: usize,
 }
 
-impl<E: Engine> SpartanVerifierCircuit<E> {
+impl<E: Engine> VegaVerifierCircuit<E> {
   pub fn default(num_rounds_x: usize, num_rounds_y: usize, mr_commitment_width: usize) -> Self {
     Self {
       outer_polys: vec![[E::Scalar::ZERO; 4]; num_rounds_x],
@@ -277,7 +277,7 @@ impl<E: Engine> SpartanVerifierCircuit<E> {
   }
 }
 
-impl<E: Engine> MultiRoundCircuit<E> for SpartanVerifierCircuit<E> {
+impl<E: Engine> MultiRoundCircuit<E> for VegaVerifierCircuit<E> {
   fn num_challenges(&self, round_index: usize) -> Result<usize, SynthesisError> {
     if round_index < self.idx_inner_final() {
       Ok(1)
@@ -470,7 +470,7 @@ impl<E: Engine> MultiRoundCircuit<E> for SpartanVerifierCircuit<E> {
 
 /// NeutronNova verifier circuit constraining computation across multiple rounds.
 #[derive(Clone, Debug)]
-pub struct NeutronNovaVerifierCircuit<E: Engine> {
+pub struct VegaMcVerifierCircuit<E: Engine> {
   // NeutronNova folding scheme verifier state across multiple rounds
   // NIFS cubic sum-check polynomials (4 coeffs per round)
   pub(crate) nifs_polys: Vec<[E::Scalar; 4]>,
@@ -504,7 +504,7 @@ pub struct NeutronNovaVerifierCircuit<E: Engine> {
   pub(crate) mr_commitment_width: usize,
 }
 
-impl<E: Engine> NeutronNovaVerifierCircuit<E> {
+impl<E: Engine> VegaMcVerifierCircuit<E> {
   /// Creates a default instance of the NeutronNova verifier circuit with zeroed fields.
   pub fn default(
     num_rounds_z: usize,
@@ -579,7 +579,7 @@ impl<E: Engine> NeutronNovaVerifierCircuit<E> {
   }
 }
 
-impl<E: Engine> MultiRoundCircuit<E> for NeutronNovaVerifierCircuit<E> {
+impl<E: Engine> MultiRoundCircuit<E> for VegaMcVerifierCircuit<E> {
   fn num_challenges(&self, round_index: usize) -> Result<usize, SynthesisError> {
     if round_index < self.num_nifs_rounds() {
       Ok(1)


### PR DESCRIPTION
Rename the crate and proof-system modules to a Vega (it targets low-latency, repeated client-side proving over the same signed data, not throughput).