### PR TITLE
Harden checks to prevent public API misuse and make some modules crate private

### DIFF
--- a/src/bellpepper/mod.rs
+++ b/src/bellpepper/mod.rs
@@ -159,6 +159,48 @@ mod tests {
     test_multiround_bits_with::<PallasHyraxEngine>();
   }
 
+  #[test]
+  fn test_multiround_validate_rejects_length_mismatch() {
+    type E = PallasHyraxEngine;
+    let circuit = TwoRoundBitsCircuit;
+
+    let (shape, ck, _vk) =
+      <ShapeCS<E> as MultiRoundVegaShape<E>>::multiround_r1cs_shape(&circuit).unwrap();
+    let mut state = SatisfyingAssignment::<E>::initialize_multiround_witness(&shape).unwrap();
+    let mut transcript = <E as Engine>::TE::new(b"test");
+    let num_rounds = <TwoRoundBitsCircuit as MultiRoundCircuit<E>>::num_rounds(&circuit);
+    for r in 0..num_rounds {
+      let _ = SatisfyingAssignment::<E>::process_round(
+        &mut state,
+        &shape,
+        &ck,
+        &circuit,
+        r,
+        &mut transcript,
+      )
+      .unwrap();
+    }
+    let (instance, _witness) =
+      SatisfyingAssignment::<E>::finalize_multiround_witness(&mut state, &shape).unwrap();
+
+    // the well-formed instance validates
+    let mut t = <E as Engine>::TE::new(b"test");
+    assert!(instance.validate(&shape, &mut t).is_ok());
+
+    // an over-length public_values vector is rejected
+    let mut bad = instance.clone();
+    bad.public_values.push(<E as Engine>::Scalar::from(1u64));
+    let mut t = <E as Engine>::TE::new(b"test");
+    assert!(bad.validate(&shape, &mut t).is_err());
+
+    // an extra per-round commitment is rejected
+    let mut bad = instance.clone();
+    let extra = bad.comm_w_per_round[0].clone();
+    bad.comm_w_per_round.push(extra);
+    let mut t = <E as Engine>::TE::new(b"test");
+    assert!(bad.validate(&shape, &mut t).is_err());
+  }
+
   // ------------------------------------------------------------
   // Multi-round permutation circuit test
   // ------------------------------------------------------------

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,7 +42,7 @@ mod polys;
 mod sumcheck;
 
 // public modules for proof systems
-pub mod spartan_relaxed; // single-circuit prover for relaxed R1CS (non-ZK)
+pub(crate) mod spartan_relaxed; // single-circuit prover for relaxed R1CS (non-ZK)
 pub mod vega_mc_zkp; // multi-circuit (NeutronNova folding) prover with zero-knowledge
 pub mod vega_sc; // single-circuit (Spartan) prover without zero-knowledge
 pub mod vega_sc_zkp; // single-circuit (Spartan) prover with zero-knowledge

--- a/src/nifs.rs
+++ b/src/nifs.rs
@@ -40,6 +40,13 @@ where
     W2: &R1CSWitness<E>,
     transcript: &mut E::TE,
   ) -> Result<(Self, RelaxedR1CSWitness<E>, E::Scalar, Vec<E::Scalar>), VegaError> {
+    // Folding combines the instances coordinate-wise, so their public IO must align.
+    if U1.X.len() != U2.X.len() {
+      return Err(VegaError::InvalidInputLength {
+        reason: "NIFS::prove: instances have mismatched public IO lengths".into(),
+      });
+    }
+
     // Use the caller-provided transcript and absorb both instances.
     transcript.absorb(b"U1", U1);
     transcript.absorb(b"U2", U2);
@@ -68,6 +75,13 @@ where
     U1: &RelaxedR1CSInstance<E>,
     U2: &R1CSInstance<E>,
   ) -> Result<RelaxedR1CSInstance<E>, VegaError> {
+    // Folding combines the instances coordinate-wise, so their public IO must align.
+    if U1.X.len() != U2.X.len() {
+      return Err(VegaError::InvalidInputLength {
+        reason: "NIFS::verify: instances have mismatched public IO lengths".into(),
+      });
+    }
+
     transcript.absorb(b"U1", U1);
     transcript.absorb(b"U2", U2);
     transcript.absorb(b"comm_T", &self.comm_T);

--- a/src/provider/pcs/hyrax_pc.rs
+++ b/src/provider/pcs/hyrax_pc.rs
@@ -498,6 +498,23 @@ where
 
     let (num_vars_rows, _num_vars_cols) = (num_rows.log_2(), num_cols.log_2());
 
+    // The commitment must have enough rows to open at this point, and the
+    // evaluation commitment must be non-empty.
+    if comm.comm.len() < num_rows {
+      return Err(VegaError::InvalidCommitmentLength {
+        reason: format!(
+          "Hyrax verify: commitment has {} rows, fewer than the {} required",
+          comm.comm.len(),
+          num_rows
+        ),
+      });
+    }
+    if comm_eval.comm.is_empty() {
+      return Err(VegaError::InvalidCommitmentLength {
+        reason: "Hyrax verify: evaluation commitment is empty".to_string(),
+      });
+    }
+
     let (comm_LZ, R) = if num_vars_rows == 0 {
       let R = EqPolynomial::new(point.to_vec()).evals();
       (comm.comm[0], R)
@@ -673,16 +690,24 @@ where
     let num_rows = div_ceil(n, num_cols);
     let num_vars_rows = num_rows.log_2();
 
-    // Compute the RLC commitment from row commitments
-    // Commitment may have fewer rows than padded num_rows (unpadded rows are zero commitments + blind*H)
+    // A direct opening commits the (folded) witness, which may carry fewer rows than the
+    // padded point space; the omitted high rows are zero commitments that contribute
+    // identity to the row combination. The commitment must therefore be non-empty and
+    // carry at most `num_rows` rows.
+    if comm.comm.is_empty() || comm.comm.len() > num_rows {
+      return Err(VegaError::InvalidCommitmentLength {
+        reason: format!(
+          "Direct opening: commitment row count {} is invalid (expected 1..={})",
+          comm.comm.len(),
+          num_rows
+        ),
+      });
+    }
+
     let comm_LZ = if num_vars_rows == 0 {
       comm.comm[0]
     } else {
       let L = EqPolynomial::new(point[..num_vars_rows].to_vec()).evals();
-      // Only sum over actual commitment rows; padding rows contribute identity (all-zero poly + zero blind)
-      // The actual commitment rows already include blinding, so we sum L[i] * comm[i] for existing rows
-      // For padded rows beyond comm.comm.len(), the commitment was zero + blind*H with blind=0
-      // (padding rows have zero polynomial and zero blind since the blind vector is only as long as actual rows)
       let actual_rows = comm.comm.len();
       let ck_aff: Vec<_> = comm.comm.iter().map(|c| c.affine()).collect();
       E::GE::vartime_multiscalar_mul(&L[..actual_rows], &ck_aff, true)?
@@ -871,5 +896,148 @@ where
     }
 
     Ok(HyraxCommitment { comm })
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::{
+    provider::PallasHyraxEngine,
+    traits::{Engine, pcs::PCSEngineTrait, transcript::TranscriptEngineTrait},
+  };
+
+  type E = PallasHyraxEngine;
+  type Scalar = <E as Engine>::Scalar;
+
+  fn sample_poly(n: usize) -> Vec<Scalar> {
+    (0..n).map(|i| Scalar::from(i as u64 + 1)).collect()
+  }
+
+  fn sample_point(num_vars: usize) -> Vec<Scalar> {
+    (0..num_vars).map(|i| Scalar::from(i as u64 + 7)).collect()
+  }
+
+  // At the direct-opening boundary an empty or oversized commitment is rejected, and a
+  // short commitment inconsistent with the opening fails the binding check.
+  #[test]
+  fn hyrax_direct_opening_rejects_malformed_commitment_rows() {
+    let width = 32;
+    let num_vars = 6; // n = 64 -> num_rows = 2
+    let n = 1usize << num_vars;
+    let (ck, vk_ee) = <E as Engine>::PCS::setup(b"test_direct", n, width);
+    let poly = sample_poly(n);
+    let point = sample_point(num_vars);
+    let blind = <E as Engine>::PCS::blind(&ck, n);
+    let comm = <E as Engine>::PCS::commit(&ck, &poly, &blind, false).unwrap();
+
+    let (v, cb) = <E as Engine>::PCS::prove_direct(&ck, &poly, &blind, &point).unwrap();
+
+    // Well-formed commitment opens successfully.
+    assert!(<E as Engine>::PCS::verify_direct(&vk_ee, &comm, &v, &cb, &point).is_ok());
+
+    // Extra row.
+    let mut comm_extra = comm.clone();
+    comm_extra.comm.push(comm.comm[0]);
+    assert!(<E as Engine>::PCS::verify_direct(&vk_ee, &comm_extra, &v, &cb, &point).is_err());
+
+    // Missing row.
+    let mut comm_short = comm.clone();
+    comm_short.comm.pop();
+    assert!(<E as Engine>::PCS::verify_direct(&vk_ee, &comm_short, &v, &cb, &point).is_err());
+
+    // Empty commitment.
+    let comm_empty = HyraxCommitment::<E> { comm: vec![] };
+    assert!(<E as Engine>::PCS::verify_direct(&vk_ee, &comm_empty, &v, &cb, &point).is_err());
+  }
+
+  // The single-row case (num_vars_rows == 0) must reject an empty commitment.
+  #[test]
+  fn hyrax_direct_opening_rejects_empty_single_row_commitment() {
+    let width = 32;
+    let num_vars = 4; // n = 16 -> num_rows = 1
+    let n = 1usize << num_vars;
+    let (ck, vk_ee) = <E as Engine>::PCS::setup(b"test_direct_single", n, width);
+    let poly = sample_poly(n);
+    let point = sample_point(num_vars);
+    let blind = <E as Engine>::PCS::blind(&ck, n);
+
+    let (v, cb) = <E as Engine>::PCS::prove_direct(&ck, &poly, &blind, &point).unwrap();
+    let comm_empty = HyraxCommitment::<E> { comm: vec![] };
+    assert!(<E as Engine>::PCS::verify_direct(&vk_ee, &comm_empty, &v, &cb, &point).is_err());
+  }
+
+  // The standard evaluation-opening boundary rejects a polynomial commitment too small
+  // to open at the point, and an empty evaluation commitment.
+  #[test]
+  fn hyrax_opening_rejects_undersized_commitments() {
+    let width = 32;
+    let num_vars = 6; // n = 64 -> num_rows = 2
+    let n = 1usize << num_vars;
+    let (ck, vk_ee) = <E as Engine>::PCS::setup(b"test_open", n, width);
+    let (ck_s, _) = <E as Engine>::PCS::setup(b"ck_s", 1, 1);
+    let poly = sample_poly(n);
+    let point = sample_point(num_vars);
+    let blind = <E as Engine>::PCS::blind(&ck, n);
+    let comm = <E as Engine>::PCS::commit(&ck, &poly, &blind, false).unwrap();
+
+    // Exact evaluation certified by the opening.
+    let (v, cb) = <E as Engine>::PCS::prove_direct(&ck, &poly, &blind, &point).unwrap();
+    let eval = <E as Engine>::PCS::verify_direct(&vk_ee, &comm, &v, &cb, &point).unwrap();
+    let blind_eval = <E as Engine>::PCS::blind(&ck_s, 1);
+    let comm_eval = <E as Engine>::PCS::commit(&ck_s, &[eval], &blind_eval, false).unwrap();
+
+    let mut tp = <E as Engine>::TE::new(b"open");
+    let arg = <E as Engine>::PCS::prove(
+      &ck,
+      &ck_s,
+      &mut tp,
+      &comm,
+      &poly,
+      &blind,
+      &point,
+      &comm_eval,
+      &blind_eval,
+    )
+    .unwrap();
+
+    // Well-formed commitment verifies.
+    let mut tv = <E as Engine>::TE::new(b"open");
+    assert!(
+      <E as Engine>::PCS::verify(&vk_ee, &ck_s, &mut tv, &comm, &point, &comm_eval, &arg).is_ok()
+    );
+
+    // Polynomial commitment too small to open at the point.
+    let mut comm_short = comm.clone();
+    comm_short.comm.pop();
+    let mut tv = <E as Engine>::TE::new(b"open");
+    assert!(
+      <E as Engine>::PCS::verify(
+        &vk_ee,
+        &ck_s,
+        &mut tv,
+        &comm_short,
+        &point,
+        &comm_eval,
+        &arg
+      )
+      .is_err()
+    );
+
+    // Empty evaluation commitment.
+    let comm_eval_empty = HyraxCommitment::<E> { comm: vec![] };
+    let mut tv = <E as Engine>::TE::new(b"open");
+    assert!(
+      <E as Engine>::PCS::verify(
+        &vk_ee,
+        &ck_s,
+        &mut tv,
+        &comm,
+        &point,
+        &comm_eval_empty,
+        &arg
+      )
+      .is_err()
+    );
   }
 }

--- a/src/r1cs/mod.rs
+++ b/src/r1cs/mod.rs
@@ -1801,6 +1801,36 @@ impl<E: Engine> SplitMultiRoundR1CSInstance<E> {
     s: &SplitMultiRoundR1CSShape<E>,
     transcript: &mut E::TE,
   ) -> Result<(), VegaError> {
+    // The regular instance folds every per-round commitment and flattens every
+    // per-round challenge into `X`, so the instance must match the shape exactly.
+    if self.public_values.len() != s.num_public {
+      return Err(VegaError::ProofVerifyError {
+        reason: format!(
+          "public_values length ({}) does not match shape num_public ({})",
+          self.public_values.len(),
+          s.num_public
+        ),
+      });
+    }
+    if self.comm_w_per_round.len() != s.num_rounds {
+      return Err(VegaError::ProofVerifyError {
+        reason: format!(
+          "comm_w_per_round length ({}) does not match shape num_rounds ({})",
+          self.comm_w_per_round.len(),
+          s.num_rounds
+        ),
+      });
+    }
+    if self.challenges_per_round.len() != s.num_rounds {
+      return Err(VegaError::ProofVerifyError {
+        reason: format!(
+          "challenges_per_round length ({}) does not match shape num_rounds ({})",
+          self.challenges_per_round.len(),
+          s.num_rounds
+        ),
+      });
+    }
+
     // Process each round, absorbing the previous round's commitment before deriving this round's challenges
     for round in 0..s.num_rounds {
       E::PCS::check_commitment(

--- a/src/r1cs/mod.rs
+++ b/src/r1cs/mod.rs
@@ -1466,6 +1466,17 @@ impl<E: Engine> SplitR1CSInstance<E> {
         reason: "comm_W_precommitted is missing".to_string(),
       });
     }
+    // a commitment must be absent when its segment is empty
+    if S.num_shared == 0 && comm_W_shared.is_some() {
+      return Err(VegaError::InvalidCommitmentLength {
+        reason: "comm_W_shared present for an empty segment".to_string(),
+      });
+    }
+    if S.num_precommitted == 0 && comm_W_precommitted.is_some() {
+      return Err(VegaError::InvalidCommitmentLength {
+        reason: "comm_W_precommitted present for an empty segment".to_string(),
+      });
+    }
 
     if let Some(ref comm) = comm_W_shared {
       E::PCS::check_commitment(comm, S.num_shared, DEFAULT_COMMITMENT_WIDTH)?;
@@ -1497,6 +1508,8 @@ impl<E: Engine> SplitR1CSInstance<E> {
       });
     }
 
+    // A split commitment is present exactly when its segment is non-empty;
+    // `to_regular_instance` folds every present commitment into the witness commitment.
     if S.num_shared > 0 {
       if let Some(comm) = &self.comm_W_shared {
         E::PCS::check_commitment(comm, S.num_shared, DEFAULT_COMMITMENT_WIDTH)?;
@@ -1506,6 +1519,10 @@ impl<E: Engine> SplitR1CSInstance<E> {
           reason: "comm_W_shared is missing".to_string(),
         });
       }
+    } else if self.comm_W_shared.is_some() {
+      return Err(VegaError::ProofVerifyError {
+        reason: "comm_W_shared present for an empty segment".to_string(),
+      });
     }
 
     if S.num_precommitted > 0 {
@@ -1517,6 +1534,10 @@ impl<E: Engine> SplitR1CSInstance<E> {
           reason: "comm_W_precommitted is missing".to_string(),
         });
       }
+    } else if self.comm_W_precommitted.is_some() {
+      return Err(VegaError::ProofVerifyError {
+        reason: "comm_W_precommitted present for an empty segment".to_string(),
+      });
     }
 
     // obtain challenges from the transcript

--- a/src/r1cs/mod.rs
+++ b/src/r1cs/mod.rs
@@ -1485,6 +1485,18 @@ impl<E: Engine> SplitR1CSInstance<E> {
   }
 
   pub fn validate(&self, S: &SplitR1CSShape<E>, transcript: &mut E::TE) -> Result<(), VegaError> {
+    // `public_values` must have exactly `num_public` entries: the regular
+    // instance places `[public_values, challenges]` into `X`.
+    if self.public_values.len() != S.num_public {
+      return Err(VegaError::ProofVerifyError {
+        reason: format!(
+          "public_values length ({}) does not match shape num_public ({})",
+          self.public_values.len(),
+          S.num_public
+        ),
+      });
+    }
+
     if S.num_shared > 0 {
       if let Some(comm) = &self.comm_W_shared {
         E::PCS::check_commitment(comm, S.num_shared, DEFAULT_COMMITMENT_WIDTH)?;

--- a/src/r1cs/mod.rs
+++ b/src/r1cs/mod.rs
@@ -293,6 +293,29 @@ mod tests_relaxed_sample {
   fn test_random_sample() {
     test_random_sample_with::<P256HyraxEngine>();
   }
+
+  #[test]
+  fn test_fold_multiple_rejects_mismatched_x() {
+    type E = P256HyraxEngine;
+    let s = tiny_r1cs::<E>(4);
+    let (ck, _) = s.commitment_key();
+    let one = <<E as Engine>::Scalar as Field>::ONE;
+    let r_w = PCS::<E>::blind(&ck, 1);
+    let comm = PCS::<E>::commit(&ck, &[one], &r_w, false).unwrap();
+
+    let u_a = R1CSInstance::<E> {
+      comm_W: comm.clone(),
+      X: vec![one, one],
+    };
+    let u_b = R1CSInstance::<E> {
+      comm_W: comm,
+      X: vec![one, one, one],
+    };
+
+    // equal-length instances fold; mismatched public IO lengths are rejected
+    assert!(R1CSInstance::fold_multiple(&[one], &[u_a.clone(), u_a.clone()]).is_ok());
+    assert!(R1CSInstance::fold_multiple(&[one], &[u_a, u_b]).is_err());
+  }
 }
 
 /// Round `n` up to the next multiple of width.
@@ -697,8 +720,27 @@ impl<E: Engine> R1CSInstance<E> {
     E::PCS: FoldingEngineTrait<E>,
   {
     let n = Us.len();
+    if n == 0 {
+      return Err(VegaError::InvalidInputLength {
+        reason: "fold_multiple: empty instance list".into(),
+      });
+    }
+
     let w = weights_from_r::<E::Scalar>(r_bs, n);
+
+    if w.len() != n {
+      return Err(VegaError::InvalidInputLength {
+        reason: "fold_multiple: weights length mismatch".into(),
+      });
+    }
+
     let d = Us[0].X.len();
+
+    if !Us.iter().all(|U| U.X.len() == d) {
+      return Err(VegaError::InvalidInputLength {
+        reason: "fold_multiple: all X vectors must have the same length".into(),
+      });
+    }
 
     // X
     let mut X_acc = vec![E::Scalar::ZERO; d];

--- a/src/spartan_relaxed.rs
+++ b/src/spartan_relaxed.rs
@@ -73,12 +73,13 @@ fn evaluate_matrix_with_tables<E: Engine>(
 ///
 /// # Soundness note
 ///
-/// This proof does NOT absorb `comm_W`/`comm_E` into its transcript -- only `(u, X)`.
-/// It is sound only when used within an outer protocol (e.g., NIFS) that has already
-/// bound the commitments to the transcript. Do not use as a standalone proof system.
+/// This crate-internal proof does NOT absorb `comm_W`/`comm_E` into its transcript --
+/// only `(u, X)`. It is sound only when composed after a step (e.g., NIFS) that has
+/// already bound the commitments to the transcript, and is intentionally not exposed
+/// as a standalone proof system.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(bound = "")]
-pub struct RelaxedR1CSSpartanProof<E: Engine> {
+pub(crate) struct RelaxedR1CSSpartanProof<E: Engine> {
   pub(crate) sc_proof_outer: SumcheckProof<E>,
   pub(crate) claims_outer: (E::Scalar, E::Scalar, E::Scalar),
   pub(crate) sc_proof_inner: SumcheckProof<E>,
@@ -95,7 +96,7 @@ impl<E: Engine> RelaxedR1CSSpartanProof<E> {
   ///
   /// The relation is: Az * Bz = u*Cz + E, where z = (W, u, X).
   /// Takes `u` and `X` separately to avoid computing folded commitments on the prover side.
-  pub fn prove(
+  pub(crate) fn prove(
     S: &R1CSShape<E>,
     ck: &CommitmentKey<E>,
     u: &E::Scalar,
@@ -215,7 +216,7 @@ impl<E: Engine> RelaxedR1CSSpartanProof<E> {
   /// Verify a relaxed R1CS Spartan proof.
   ///
   /// The verifier provides the full folded instance (with commitments) from NIFS::verify.
-  pub fn verify(
+  pub(crate) fn verify(
     &self,
     S: &R1CSShape<E>,
     vk_ee: &<E::PCS as PCSEngineTrait<E>>::VerifierKey,

--- a/src/vega_mc_zkp.rs
+++ b/src/vega_mc_zkp.rs
@@ -1620,6 +1620,17 @@ where
     })?;
     info!(elapsed_ms = %rerandomize_t.elapsed().as_millis(), "rerandomize_prep_state");
 
+    // The prepared step state corresponds one-to-one with the step circuits.
+    if prep_snark.ps_step.len() != step_circuits.len() {
+      return Err(VegaError::InvalidInputLength {
+        reason: format!(
+          "prove received {} step circuits but prep state holds {} step instances",
+          step_circuits.len(),
+          prep_snark.ps_step.len()
+        ),
+      });
+    }
+
     // Validate that cached matvec matches current step circuit public values.
     // The cache computed in prep_prove includes public_values in the z vector;
     // if the circuits changed, the cache is stale and would produce incorrect proofs.
@@ -2490,5 +2501,15 @@ mod tests {
         );
       }
     }
+  }
+
+  #[test]
+  fn test_mc_zk_prove_rejects_prep_state_with_fewer_steps() {
+    type E = T256HyraxEngine;
+    let (pk, _vk, circuits) = generate_sha_r1cs::<E>(7, 32);
+    // Prepare with only 5 of the 7 step circuits, then prove with all 7.
+    let ps = VegaMcZkSNARK::<E>::prep_prove(&pk, &circuits[..5], &circuits[0], true).unwrap();
+    let res = VegaMcZkSNARK::prove(&pk, &circuits, &circuits[0], ps, true);
+    assert!(res.is_err());
   }
 }

--- a/src/vega_mc_zkp.rs
+++ b/src/vega_mc_zkp.rs
@@ -1291,6 +1291,7 @@ pub struct VegaMcVerifierKey<E: Engine> {
   vc_shape_regular: R1CSShape<E>,
   vc_ck: CommitmentKey<E>,
   vc_vk: VerifierKey<E>,
+  num_steps: usize,
   #[serde(skip, default = "OnceCell::new")]
   digest: OnceCell<VegaDigest>,
 }
@@ -1322,6 +1323,9 @@ impl<E: Engine> crate::digest::Digestible for VegaMcVerifierKey<E> {
       .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
     config
       .serialize_into(&mut *w, &self.vc_vk)
+      .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+    config
+      .serialize_into(&mut *w, &self.num_steps)
       .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
     Ok(())
   }
@@ -1443,6 +1447,7 @@ where
       vc_shape_regular: vc_shape_regular.clone(),
       vc_ck: vc_ck.clone(),
       vc_vk: vc_vk.clone(),
+      num_steps,
       digest: OnceCell::new(),
     };
 
@@ -2111,6 +2116,14 @@ where
         ),
       });
     }
+    if num_instances != vk.num_steps {
+      return Err(VegaError::ProofVerifyError {
+        reason: format!(
+          "Verifier key is bound to {} step instances, got {}",
+          vk.num_steps, num_instances
+        ),
+      });
+    }
 
     // Reconstruct step instances and core instance with the shared commitment
     let step_instances: Vec<SplitR1CSInstance<E>> = self
@@ -2511,5 +2524,21 @@ mod tests {
     let ps = VegaMcZkSNARK::<E>::prep_prove(&pk, &circuits[..5], &circuits[0], true).unwrap();
     let res = VegaMcZkSNARK::prove(&pk, &circuits, &circuits[0], ps, true);
     assert!(res.is_err());
+  }
+
+  #[test]
+  fn test_mc_zk_rejects_step_count_different_from_setup_count() {
+    type E = T256HyraxEngine;
+    // A valid 5-step proof under a key set up for exactly 5 steps.
+    let (pk5, vk5, circuits5) = generate_sha_r1cs::<E>(5, 32);
+    let ps = VegaMcZkSNARK::<E>::prep_prove(&pk5, &circuits5, &circuits5[0], true).unwrap();
+    let (snark, _) = VegaMcZkSNARK::prove(&pk5, &circuits5, &circuits5[0], ps, true).unwrap();
+
+    // It verifies under its own 5-step key.
+    assert!(snark.verify(&vk5, 5).is_ok());
+
+    // A key set up for a different number of steps must reject this proof.
+    let (_pk7, vk7, _c7) = generate_sha_r1cs::<E>(7, 32);
+    assert!(snark.verify(&vk7, 5).is_err());
   }
 }

--- a/src/vega_sc.rs
+++ b/src/vega_sc.rs
@@ -707,4 +707,26 @@ mod tests {
     let mut transcript = <E as Engine>::TE::new(b"test");
     assert!(snark.U.validate(&vk.S, &mut transcript).is_err());
   }
+
+  #[test]
+  fn test_validate_rejects_commitment_for_empty_segment() {
+    type E = crate::provider::PallasHyraxEngine;
+    let circuit = CubicCircuit::default();
+
+    let (pk, vk) = VegaSNARK::<E>::setup(circuit.clone()).unwrap();
+    let prep_snark = VegaSNARK::<E>::prep_prove(&pk, circuit.clone(), false).unwrap();
+    let (mut snark, _prep_snark) = VegaSNARK::<E>::prove(&pk, circuit, prep_snark, false).unwrap();
+
+    // this circuit has no shared segment
+    assert_eq!(vk.S.num_shared, 0);
+
+    // a well-formed instance passes validation
+    let mut transcript = <E as Engine>::TE::new(b"test");
+    assert!(snark.U.validate(&vk.S, &mut transcript).is_ok());
+
+    // a commitment supplied for the empty shared segment is rejected
+    snark.U.comm_W_shared = Some(snark.U.comm_W_rest.clone());
+    let mut transcript = <E as Engine>::TE::new(b"test");
+    assert!(snark.U.validate(&vk.S, &mut transcript).is_err());
+  }
 }

--- a/src/vega_sc.rs
+++ b/src/vega_sc.rs
@@ -685,4 +685,26 @@ mod tests {
     assert!(res.is_ok());
     assert_eq!(res.unwrap(), [<E as Engine>::Scalar::from(15u64)])
   }
+
+  #[test]
+  fn test_validate_rejects_overlong_public_io() {
+    type E = crate::provider::PallasHyraxEngine;
+    let circuit = CubicCircuit::default();
+
+    let (pk, vk) = VegaSNARK::<E>::setup(circuit.clone()).unwrap();
+    let prep_snark = VegaSNARK::<E>::prep_prove(&pk, circuit.clone(), false).unwrap();
+    let (mut snark, _prep_snark) = VegaSNARK::<E>::prove(&pk, circuit, prep_snark, false).unwrap();
+
+    // a well-formed instance passes validation
+    let mut transcript = <E as Engine>::TE::new(b"test");
+    assert!(snark.U.validate(&vk.S, &mut transcript).is_ok());
+
+    // a `public_values` length that does not match `num_public` is rejected
+    snark
+      .U
+      .public_values
+      .push(<E as Engine>::Scalar::from(42u64));
+    let mut transcript = <E as Engine>::TE::new(b"test");
+    assert!(snark.U.validate(&vk.S, &mut transcript).is_err());
+  }
 }


### PR DESCRIPTION
Tightens shape/length validation at verification and folding boundaries so the verifier rejects (rather than mis-handles or panics on) malformed instances, and binds proof statements more precisely to their declared shape.

credit: nicoarq