### PR TITLE
Avoid panic in verifier

### DIFF
--- a/src/polys/univariate.rs
+++ b/src/polys/univariate.rs
@@ -117,11 +117,6 @@ impl<Scalar: PrimeField> UniPoly<Scalar> {
     }
   }
 
-  /// Returns the degree of the polynomial.
-  pub fn degree(&self) -> usize {
-    self.coeffs.len() - 1
-  }
-
   /// Evaluates the polynomial at zero.
   pub fn eval_at_zero(&self) -> Scalar {
     self.coeffs[0]
@@ -154,6 +149,19 @@ impl<Scalar: PrimeField> UniPoly<Scalar> {
 }
 
 impl<Scalar: PrimeField> CompressedUniPoly<Scalar> {
+  /// Returns the degree of the polynomial once the linear term is restored.
+  pub(crate) fn degree(&self) -> usize {
+    self.coeffs_except_linear_term.len()
+  }
+
+  /// Builds a compressed polynomial directly from its stored coefficients.
+  #[cfg(test)]
+  pub(crate) fn new_for_test(coeffs_except_linear_term: Vec<Scalar>) -> Self {
+    CompressedUniPoly {
+      coeffs_except_linear_term,
+    }
+  }
+
   // we require eval(0) + eval(1) = hint, so we can solve for the linear term as:
   // linear_term = hint - 2 * constant_term - deg2 term - deg3 term
   /// Decompresses the polynomial by reconstructing the linear coefficient.

--- a/src/sumcheck.rs
+++ b/src/sumcheck.rs
@@ -82,12 +82,13 @@ impl<E: Engine> SumcheckProof<E> {
 
     for i in 0..self.compressed_polys.len() {
       let (_round_span, round_t) = start_span!("sumcheck_verify_round", round = i);
-      let poly = self.compressed_polys[i].decompress(&e);
 
       // verify degree bound
-      if poly.degree() != degree_bound {
+      if self.compressed_polys[i].degree() != degree_bound {
         return Err(VegaError::InvalidSumcheckProof);
       }
+
+      let poly = self.compressed_polys[i].decompress(&e);
 
       // we do not need to check if poly(0) + poly(1) = e, as
       // decompress() call above already ensures that holds
@@ -1569,5 +1570,27 @@ mod perf_tests {
       test_inner_sumcheck_with::<PallasHyraxEngine>();
       test_inner_sumcheck_with::<T256HyraxEngine>();
     }
+  }
+}
+
+#[cfg(test)]
+mod verify_tests {
+  use super::SumcheckProof;
+  use crate::polys::univariate::CompressedUniPoly;
+  use crate::provider::Bn254Engine;
+  use crate::traits::{Engine, transcript::TranscriptEngineTrait};
+  use ff::Field;
+
+  // A round polynomial carrying no coefficients must be rejected during verification.
+  #[test]
+  fn test_verify_rejects_malformed_round_poly() {
+    type E = Bn254Engine;
+    let empty = CompressedUniPoly::<<E as Engine>::Scalar>::new_for_test(Vec::new());
+    let proof = SumcheckProof::<E> {
+      compressed_polys: vec![empty],
+    };
+    let mut transcript = <E as Engine>::TE::new(b"test_malformed_round");
+    let claim = <E as Engine>::Scalar::ZERO;
+    assert!(proof.verify(claim, 1, 3, &mut transcript).is_err());
   }
 }


### PR DESCRIPTION
Check each round polynomial against the degree bound on its compressed form before reconstructing it, moving the degree accessor onto the compressed representation. Add a regression test for the degree check.